### PR TITLE
✨ Support page margins

### DIFF
--- a/examples/sample.js
+++ b/examples/sample.js
@@ -10,6 +10,7 @@ export default {
       { data: fonts.DejaVu_Sans_BoldItalic, italic: true, bold: true },
     ],
   },
+  margin: { x: '2.5cm', top: '2cm', bottom: '1.5cm' },
   content: [
     { text: 'Lorem ipsum', bold: true, fontSizez: 24 },
     { text: ['dolor sit amet, consectetur ', { text: 'adipiscing elit,', italic: true }] },

--- a/src/box.ts
+++ b/src/box.ts
@@ -1,3 +1,94 @@
+import { LengthUnit } from './content.js';
+
 export type Pos = { x: number; y: number };
 export type Size = { width: number; height: number };
 export type Box = Size & Pos;
+
+export type BoxEdges = {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+};
+
+/**
+ * Computes an inner box by subtracting the given space (e.g. a padding) from the given box.
+ *
+ * @param box The outer box.
+ * @param edges The space to subtract.
+ * @returns The resulting inner box.
+ */
+export function subtractEdges(box: Box, edges: BoxEdges) {
+  return {
+    x: box.x + (edges?.left ?? 0),
+    y: box.y + (edges?.top ?? 0),
+    width: Math.max(0, box.width - (edges?.left ?? 0) - (edges?.right ?? 0)),
+    height: Math.max(0, box.height - (edges?.top ?? 0) - (edges?.bottom ?? 0)),
+  };
+}
+
+/**
+ * Parses a given value as a box lengths definition (`BoxLengths | Length`) to the lengths of the
+ * edges.
+ * Throws if the given input is invalid.
+ *
+ * @param input the input value
+ * @returns an object with the four edges in `pt`, or `undefined` if the input is missing or `null`
+ */
+export function parseEdges(input?: unknown): BoxEdges | undefined {
+  if (input == null) return undefined;
+  if (typeof input === 'number' || typeof input === 'string') {
+    const value = parseLength(input);
+    return { right: value, left: value, top: value, bottom: value };
+  }
+  if (typeof input === 'object') {
+    const obj = input as Record<string, unknown>;
+    return {
+      right: parseLength(obj.right ?? obj.x ?? 0),
+      left: parseLength(obj.left ?? obj.x ?? 0),
+      top: parseLength(obj.top ?? obj.y ?? 0),
+      bottom: parseLength(obj.bottom ?? obj.y ?? 0),
+    };
+  }
+  throw new TypeError(`Invalid box lengths: '${input}'`);
+}
+
+/**
+ * Converts a length definition into the corresponding value in points (`pt`).
+ * Throws if the given value is not a valid length.
+ *
+ * @param input the input value
+ * @returns the length in `pt`, or `undefined` if the input is missing or `null`
+ */
+export function parseLength(input?: unknown): number | undefined {
+  if (input == null) return undefined;
+  if (typeof input === 'number' && Number.isFinite(input)) {
+    return input;
+  }
+  if (typeof input === 'string') {
+    const unit = input.slice(-2);
+    if (unit === 'pt' || unit === 'in' || unit === 'mm' || unit === 'cm') {
+      const value = parseFloat(input.slice(0, -2));
+      if (Number.isFinite(value)) {
+        return convertToPt(value, unit);
+      }
+    }
+  }
+  throw new TypeError(`Invalid length: '${input}'`);
+}
+
+function convertToPt(value: number, fromUnit: LengthUnit): number {
+  // 1in = 72pt = 25.4mm
+  switch (fromUnit) {
+    case 'pt':
+      return value * 1;
+    case 'in':
+      return value * 72;
+    case 'mm':
+      return (value * 72) / 25.4;
+    case 'cm':
+      return (value * 72) / 2.54;
+    default:
+      throw new TypeError(`Invalid unit: '${fromUnit}'`);
+  }
+}

--- a/src/content.ts
+++ b/src/content.ts
@@ -7,6 +7,10 @@ export type DocumentDefinition = {
    */
   content: Paragraph[];
   /**
+   * The page margins. Defaults to 50pt on each side.
+   */
+  margin?: Length | BoxLengths;
+  /**
    * The fonts to use in the document. There is no default. Each font that is used in the document
    * must be registered. Not needed for documents that contain only graphics.
    */
@@ -64,3 +68,32 @@ export type TextAttrs = {
    */
   italic?: boolean;
 };
+
+/**
+ * A definition of space around the edges of a box.
+ * Undefined edges default to zero.
+ */
+export type BoxLengths = {
+  /** Space on the left edge, overrides `x`. */
+  left?: Length;
+  /** Space on the right edge, overrides `x`. */
+  right?: Length;
+  /** Space on the upper edge, overrides `y`. */
+  top?: Length;
+  /** Space on the lower edge, overrides `y`. */
+  bottom?: Length;
+  /** Space on the left and right edge. */
+  x?: Length;
+  /** Space on the upper and lower edge. */
+  y?: Length;
+};
+
+/**
+ * A length definition as a number, optionally followed by a unit.
+ * Supported units are `pt` (point), `in` (inch), `mm` (millimeter), and `cm` (centimeter).
+ * If the unit is left out, the number is interpreted as point (`pt`).
+ * One point is defined as `1/72` of an inch (`72pt = 1in`).
+ */
+export type Length = number | `${number}${LengthUnit}`;
+
+export type LengthUnit = 'pt' | 'in' | 'mm' | 'cm';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { subtractEdges } from './box.js';
 import { DocumentDefinition } from './content.js';
 import { createDocument } from './document.js';
 import { embedFonts } from './fonts.js';
@@ -7,8 +8,8 @@ import { createPage, renderPage } from './page.js';
 export async function makePdf(def: DocumentDefinition) {
   const doc = await createDocument();
   const fonts = await embedFonts(def.fonts, doc);
-  const page = createPage(doc);
-  const box = { x: 0, y: 0, ...page.size };
+  const page = createPage(doc, def);
+  const box = subtractEdges({ x: 0, y: 0, ...page.size }, page.margin);
   const frame = layoutPage(def.content, box, fonts);
   renderPage(frame, page);
   const pdf = await doc.save();

--- a/src/page.ts
+++ b/src/page.ts
@@ -1,17 +1,22 @@
 import { PDFDocument, PDFPage, PDFPageDrawTextOptions } from 'pdf-lib';
 
-import { Pos, Size } from './box.js';
+import { BoxEdges, parseEdges, Pos, Size } from './box.js';
+import { DocumentDefinition } from './content.js';
 import { Frame, TextObject } from './layout.js';
+
+const defaultPageMargin = '2cm';
 
 export type Page = {
   pdfPage: PDFPage;
   size: Size;
+  margin: BoxEdges;
 };
 
-export function createPage(doc: PDFDocument): Page {
+export function createPage(doc: PDFDocument, def: DocumentDefinition): Page {
   const pdfPage = doc.addPage();
   const size = pdfPage.getSize();
-  return { pdfPage, size };
+  const margin = parseEdges(def.margin ?? defaultPageMargin);
+  return { pdfPage, size, margin };
 }
 
 export function renderPage(frame: Frame, page: Page) {

--- a/test/box.test.ts
+++ b/test/box.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { parseEdges, parseLength, subtractEdges } from '../src/box.js';
+import { BoxLengths } from '../src/content.js';
+
+describe('box', () => {
+  describe('subtractEdges', () => {
+    it('returns the original box if edges are null', () => {
+      const box = { x: 10, y: 20, width: 300, height: 400 };
+
+      expect(subtractEdges(box, null)).toEqual(box);
+    });
+
+    it('subtracts all edges correctly', () => {
+      const box = { x: 10, y: 20, width: 300, height: 400 };
+      const edges = { left: 1, right: 2, top: 3, bottom: 4 };
+
+      const inner = subtractEdges(box, edges);
+
+      expect(inner).toEqual({ x: 11, y: 23, width: 297, height: 393 });
+    });
+
+    it('clamps width and height to zero', () => {
+      const box = { x: 10, y: 20, width: 300, height: 400 };
+      const edges = { left: 200, right: 200, top: 300, bottom: 300 };
+
+      const inner = subtractEdges(box, edges);
+
+      expect(inner).toEqual({ x: 210, y: 320, width: 0, height: 0 });
+    });
+  });
+
+  describe('parseEdges', () => {
+    it('return undefined for missing input', () => {
+      expect(parseEdges()).toBeUndefined();
+      expect(parseEdges(null)).toBeUndefined();
+      expect(parseEdges(undefined)).toBeUndefined();
+    });
+
+    it('supports number', () => {
+      expect(parseEdges(0)).toEqual({ left: 0, right: 0, top: 0, bottom: 0 });
+      expect(parseEdges(1)).toEqual({ left: 1, right: 1, top: 1, bottom: 1 });
+    });
+
+    it('supports string', () => {
+      expect(parseEdges('0in')).toEqual({ left: 0, right: 0, top: 0, bottom: 0 });
+      expect(parseEdges('1in')).toEqual({ left: 72, right: 72, top: 72, bottom: 72 });
+    });
+
+    it('supports empty margin', () => {
+      expect(parseEdges({})).toEqual({ left: 0, right: 0, top: 0, bottom: 0 });
+    });
+
+    it('supports x and y', () => {
+      expect(parseEdges({ x: 2 })).toEqual({ left: 2, right: 2, top: 0, bottom: 0 });
+      expect(parseEdges({ y: 3 })).toEqual({ left: 0, right: 0, top: 3, bottom: 3 });
+      expect(parseEdges({ x: 2, y: 3 })).toEqual({ left: 2, right: 2, top: 3, bottom: 3 });
+    });
+
+    it('supports left, right, top, and bottom', () => {
+      const margin = { left: 1, right: 2, top: 3, bottom: 4 };
+
+      expect(parseEdges(margin)).toEqual(margin);
+    });
+
+    it('gives left and right precedence over x', () => {
+      const margin = { x: 1, right: 2, left: 3 };
+
+      expect(parseEdges(margin)).toEqual({ left: 3, right: 2, top: 0, bottom: 0 });
+    });
+
+    it('gives top and bottom precedence over y', () => {
+      const margin = { y: 1, top: 2, bottom: 3 };
+
+      expect(parseEdges(margin)).toEqual({ left: 0, right: 0, top: 2, bottom: 3 });
+    });
+
+    it('resolves units', () => {
+      const margin = { x: '1in', y: 2 } as BoxLengths;
+
+      expect(parseEdges(margin)).toEqual({ left: 72, right: 72, top: 2, bottom: 2 });
+    });
+
+    it('throws on invalid lengths', () => {
+      expect(() => parseEdges('')).toThrowError("Invalid length: ''");
+      expect(() => parseEdges(Infinity)).toThrowError("Invalid length: 'Infinity'");
+    });
+
+    it('throws on invalid types', () => {
+      expect(() => parseEdges('')).toThrowError("Invalid length: ''");
+      expect(() => parseEdges(true)).toThrowError("Invalid box lengths: 'true'");
+      expect(() => parseEdges(() => 23)).toThrowError("Invalid box lengths: '() => 23'");
+    });
+  });
+
+  describe('parseLength', () => {
+    it('return undefined for missing input', () => {
+      expect(parseLength()).toBeUndefined();
+      expect(parseLength(null)).toBeUndefined();
+      expect(parseLength(undefined)).toBeUndefined();
+    });
+
+    it('supports numbers', () => {
+      expect(parseLength(0)).toEqual(0);
+      expect(parseLength(-1)).toEqual(-1);
+      expect(parseLength(10)).toEqual(10);
+      expect(parseLength(0.1)).toEqual(0.1);
+    });
+
+    it('supports strings with unit pt', () => {
+      expect(parseLength('0pt')).toEqual(0);
+      expect(parseLength('-1pt')).toEqual(-1);
+      expect(parseLength('10pt')).toEqual(10);
+      expect(parseLength('0.1pt')).toEqual(0.1);
+    });
+
+    it('supports strings with unit in', () => {
+      expect(parseLength('0in')).toEqual(0);
+      expect(parseLength('1in')).toEqual(72);
+    });
+
+    it('supports strings with unit mm', () => {
+      expect(parseLength('0mm')).toEqual(0);
+      expect(parseLength('25.4mm')).toBeCloseTo(72);
+    });
+
+    it('supports strings with unit cm', () => {
+      expect(parseLength('0cm')).toEqual(0);
+      expect(parseLength('2.54cm')).toBeCloseTo(72);
+    });
+
+    it('throws on invalid strings', () => {
+      expect(() => parseLength('')).toThrowError("Invalid length: ''");
+      expect(() => parseLength('1')).toThrowError("Invalid length: '1'");
+      expect(() => parseLength('1xy')).toThrowError("Invalid length: '1xy'");
+    });
+
+    it('throws on invalid numbers', () => {
+      expect(() => parseLength(Infinity)).toThrowError("Invalid length: 'Infinity'");
+      expect(() => parseLength(NaN)).toThrowError("Invalid length: 'NaN'");
+    });
+
+    it('throws on invalid types', () => {
+      expect(() => parseLength(true)).toThrowError("Invalid length: 'true'");
+      expect(() => parseLength(() => 23)).toThrowError("Invalid length: '() => 23'");
+    });
+  });
+});

--- a/test/page.test.ts
+++ b/test/page.test.ts
@@ -1,20 +1,42 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { PDFContext, PDFFont } from 'pdf-lib';
 
+import { parseEdges } from '../src/box.js';
+import { BoxLengths } from '../src/content.js';
 import { Frame } from '../src/layout.js';
 import { createPage, renderFrame } from '../src/page.js';
 import { fakePdfFont } from './test-utils.js';
 
+const { anything, objectContaining } = expect;
+
 describe('page', () => {
   describe('createPage', () => {
-    it('creates page and return wrapper', () => {
-      const size = { width: 300, height: 400 };
-      const pdfPage = { getSize: () => size };
-      const doc = { addPage: jest.fn().mockReturnValue(pdfPage) } as any;
+    let size, pdfPage, doc;
 
-      const page = createPage(doc);
+    beforeEach(() => {
+      size = { width: 300, height: 400 };
+      pdfPage = { getSize: () => size };
+      doc = { addPage: jest.fn().mockReturnValue(pdfPage) } as any;
+    });
 
-      expect(page).toEqual({ pdfPage, size });
+    it('creates page and returns wrapper', () => {
+      const page = createPage(doc, {} as any);
+
+      expect(page).toEqual({ pdfPage, size, margin: anything() });
+    });
+
+    it('includes a default margin of 2cm', () => {
+      const page = createPage(doc, {} as any);
+
+      expect(page).toEqual(objectContaining({ margin: parseEdges('2cm') }));
+    });
+
+    it('includes margin from document definition', () => {
+      const margin: BoxLengths = { left: '1cm', right: '2cm', top: '3cm', bottom: '4cm' };
+
+      const page = createPage(doc, { margin } as any);
+
+      expect(page).toEqual(objectContaining({ margin: parseEdges(margin) }));
     });
   });
 


### PR DESCRIPTION
Support a page margin in the document definition.
To allow specifying the margin using common units, support strings that
include a number followed by a unit, as usual in CSS.
Support the units `pt` and `in` (inch), as well as the metric units `mm`
and `cm`.
These units can later also be used for other definitions such as
paddings in paragraphs.

Create functions to parse lengths with units and translate them to pt.
1 pt, defined as 1/72 inch is the default unit in a PDF document, all
layout and rendering is based on this unit.

Create a function to subtract edges from a box and ensure that the
resulting box cannot have negative widths or height.