### PR TITLE
✨ Support guides to assist during development

### DIFF
--- a/examples/sample.js
+++ b/examples/sample.js
@@ -2,6 +2,7 @@
 import fonts from './generated/fonts.js';
 
 export default {
+  dev: { guides: true },
   fonts: {
     'DejaVu-Sans': [
       { data: fonts.DejaVu_Sans_Normal },

--- a/src/content.ts
+++ b/src/content.ts
@@ -15,6 +15,12 @@ export type DocumentDefinition = {
    * must be registered. Not needed for documents that contain only graphics.
    */
   fonts?: FontsDefinition;
+  dev?: {
+    /**
+     * Whether to draw a thin colored rectangle around each rendered frame.
+     */
+    guides?: boolean;
+  };
 };
 
 export type FontsDefinition = { [name: string]: FontDefinition[] };

--- a/src/guides.ts
+++ b/src/guides.ts
@@ -1,0 +1,31 @@
+import { rgb } from 'pdf-lib';
+
+import { Box } from './box.js';
+import { Page } from './page.js';
+
+export function renderGuide(page: Page, box: Box, type: string) {
+  if (page.guides) {
+    const { x, y, width, height } = box;
+    const color = getColor(type);
+    page.pdfPage.drawRectangle({
+      x,
+      y,
+      width,
+      height,
+      borderColor: color,
+      borderWidth: 0.5,
+      borderOpacity: 0.25,
+    });
+  }
+}
+
+function getColor(type: string) {
+  switch (type) {
+    case 'page':
+      return rgb(1, 0, 0);
+    case 'row':
+      return rgb(0, 0.5, 0);
+    default:
+      return rgb(0, 0, 0);
+  }
+}

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -15,6 +15,7 @@ export type Frame = {
   y: number;
   width: number;
   height: number;
+  type?: string;
   objects?: TextObject[];
   children?: Frame[];
 };
@@ -41,7 +42,7 @@ export function layoutPage(content: Paragraph[], box: Box, fonts: Font[]): Frame
     pos.y += frame.height;
     remainingHeight = height - pos.y;
   });
-  return { x, y, width, height, children };
+  return { type: 'page', x, y, width, height, children };
 }
 
 function layoutParagraph(content: Paragraph, box: Box, fonts: Font[]): Frame {

--- a/src/page.ts
+++ b/src/page.ts
@@ -2,6 +2,7 @@ import { PDFDocument, PDFPage, PDFPageDrawTextOptions } from 'pdf-lib';
 
 import { BoxEdges, parseEdges, Pos, Size } from './box.js';
 import { DocumentDefinition } from './content.js';
+import { renderGuide } from './guides.js';
 import { Frame, TextObject } from './layout.js';
 
 const defaultPageMargin = '2cm';
@@ -10,13 +11,14 @@ export type Page = {
   pdfPage: PDFPage;
   size: Size;
   margin: BoxEdges;
+  guides?: boolean;
 };
 
 export function createPage(doc: PDFDocument, def: DocumentDefinition): Page {
   const pdfPage = doc.addPage();
   const size = pdfPage.getSize();
   const margin = parseEdges(def.margin ?? defaultPageMargin);
-  return { pdfPage, size, margin };
+  return { pdfPage, size, margin, guides: def.dev?.guides };
 }
 
 export function renderPage(frame: Frame, page: Page) {
@@ -24,8 +26,10 @@ export function renderPage(frame: Frame, page: Page) {
 }
 
 export function renderFrame(frame: Frame, page: Page, base: Pos = null) {
+  const { width, height } = frame;
   const topLeft = { x: frame.x + (base?.x ?? 0), y: frame.y + (base?.y ?? 0) };
-  const bottomLeft = { x: topLeft.x, y: topLeft.y + frame.height };
+  const bottomLeft = { x: topLeft.x, y: topLeft.y + height };
+  renderGuide(page, { ...tr(bottomLeft, page), width, height }, frame.type);
   frame.children?.forEach((frame) => {
     renderFrame(frame, page, topLeft);
   });

--- a/test/layout.test.ts
+++ b/test/layout.test.ts
@@ -15,7 +15,7 @@ describe('layout', () => {
     it('returns empty page frame for empty content', () => {
       const frame = layoutPage([], box, fonts);
 
-      expect(frame).toEqual({ ...box, children: [] });
+      expect(frame).toEqual({ type: 'page', ...box, children: [] });
     });
 
     it('returns a page with a single text row for single text content', () => {
@@ -24,7 +24,7 @@ describe('layout', () => {
       const frame = layoutPage(content, box, fonts);
 
       expect(frame).toEqual({
-        ...box,
+        ...{ type: 'page', ...box },
         children: [
           {
             ...{ type: 'row', x: 0, y: 0, width: 162, height: 18 },


### PR DESCRIPTION
Being able to see the exact edges of each rendered frame can be very
handy while developing layout algorithms.

Draw a thin colored rectangle around each frame. Support different
colors for different types of frames, depending on their `type`
attribute. Currently, there's only the `page` frame and `row` frames.
Over time, frames for multi-row paragraphs, or maybe columns will be
added.

Those guides can also be helpful for users of this library.

Introduce an optional `dev` element in the document definition for
developer-related settings. Add an optional attribute `guides` to this
structure to enable drawing of these guides.