### PR TITLE
✨ Support document metadata

### DIFF
--- a/examples/sample.js
+++ b/examples/sample.js
@@ -2,6 +2,13 @@
 import fonts from './generated/fonts.js';
 
 export default {
+  info: {
+    title: 'PDF Maker sample',
+    author: 'John Doe',
+    subject: 'Lorem ipsum',
+    keywords: ['lorem', 'ipsum'],
+    creator: 'PDF Maker',
+  },
   dev: { guides: true },
   fonts: {
     'DejaVu-Sans': [

--- a/src/content.ts
+++ b/src/content.ts
@@ -15,6 +15,39 @@ export type DocumentDefinition = {
    * must be registered. Not needed for documents that contain only graphics.
    */
   fonts?: FontsDefinition;
+  /**
+   * Metadata to include in the document.
+   */
+  info?: {
+    /**
+     * The document’s title.
+     */
+    title?: string;
+    /**
+     * The name of the person who created the document.
+     */
+    author?: string;
+    /**
+     * The subject of the document.
+     */
+    subject?: string;
+    /**
+     * Keywords associated with the document.
+     */
+    keywords?: string[];
+    /**
+     * The date and time the document was created (defaults to current time).
+     */
+    creationDate?: Date;
+    /**
+     * The name of the application that created the original content.
+     */
+    creator?: string;
+    /**
+     * The name of the application that created the PDF.
+     */
+    producer?: string;
+  };
   dev?: {
     /**
      * Whether to draw a thin colored rectangle around each rendered frame.

--- a/src/document.ts
+++ b/src/document.ts
@@ -1,8 +1,35 @@
 import fontkit from '@pdf-lib/fontkit';
 import { PDFDocument } from 'pdf-lib';
 
-export async function createDocument() {
+import { DocumentDefinition } from './content.js';
+
+export async function createDocument(def: DocumentDefinition) {
   const doc = await PDFDocument.create();
   doc.registerFontkit(fontkit);
+  setMetadata(doc, def);
   return doc;
+}
+
+function setMetadata(doc: PDFDocument, def: DocumentDefinition) {
+  if (def.info?.title) {
+    doc.setTitle(def.info.title);
+  }
+  if (def.info?.subject) {
+    doc.setSubject(def.info.subject);
+  }
+  if (def.info?.keywords) {
+    doc.setKeywords(def.info.keywords);
+  }
+  if (def.info?.author) {
+    doc.setAuthor(def.info.author);
+  }
+  if (def.info?.creationDate) {
+    doc.setCreationDate(def.info.creationDate);
+  }
+  if (def.info?.creator) {
+    doc.setCreator(def.info.creator);
+  }
+  if (def.info?.producer) {
+    doc.setProducer(def.info.producer);
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { layoutPage } from './layout.js';
 import { createPage, renderPage } from './page.js';
 
 export async function makePdf(def: DocumentDefinition) {
-  const doc = await createDocument();
+  const doc = await createDocument(def);
   const fonts = await embedFonts(def.fonts, doc);
   const page = createPage(doc, def);
   const box = subtractEdges({ x: 0, y: 0, ...page.size }, page.margin);


### PR DESCRIPTION
Support adding metadata to the created PDF document.

Introduce an `info` element in the document definition with fields for
all common entries in the *Document Information Dictionary*, an optional
dictionary in a PDF file that contains metadata.

See Adobe PDF 1.7, section 10.2.1