### PR TITLE
⚡️ Measure execution time when creating example

### DIFF
--- a/scripts/make-examples.js
+++ b/scripts/make-examples.js
@@ -50,12 +50,14 @@ async function makeExample(makePdf, path) {
   const name = path.replace(/^.*\/(.*)\.[a-z]+$/, '$1');
   const example = await importExample(join('..', path));
   if (example.default) {
+    const start = Date.now();
     const result = await makePdf(example.default);
+    const duration = Date.now() - start;
     const outfile = join('out', name + '.pdf');
     await mkdir('out', { recursive: true });
     await writeFile(join('out', name + '.pdf'), result);
 
-    console.log(`created ${outfile} with ${result.byteLength} bytes`);
+    console.log(`created ${outfile} with ${result.byteLength} bytes (${duration} ms)`);
   }
 }
 


### PR DESCRIPTION
Performance is critical when creating PDF documents in Web apps or
mobile apps. To help keeping an eye on performance, measure the duration
of PDF creation when creating the example PDF file and print it to the
console.