### PR TITLE
✨ Support lineHeight attribute

### DIFF
--- a/examples/sample.js
+++ b/examples/sample.js
@@ -13,7 +13,7 @@ export default {
   },
   margin: { x: '2.5cm', top: '2cm', bottom: '1.5cm' },
   content: [
-    { text: 'Lorem ipsum', bold: true, fontSizez: 24 },
+    { text: 'Lorem ipsum', bold: true, fontSize: 24, lineHeight: 1.5 },
     { text: ['dolor sit amet, consectetur ', { text: 'adipiscing elit,', italic: true }] },
     { text: 'sed do eiusmod tempor incididunt ut labore' },
     { text: ['et ', { text: 'dolore magna', bold: true, italic: true }, ' aliqua.'] },

--- a/src/content.ts
+++ b/src/content.ts
@@ -66,6 +66,10 @@ export type TextAttrs = {
    */
   fontSize?: number;
   /**
+   * The line height as a multiple of the font size. Defaults to `1.2`.
+   */
+  lineHeight?: number;
+  /**
    * Whether to use a bold variant of the selected font.
    */
   bold?: boolean;

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -56,15 +56,16 @@ function layoutParagraph(content: Paragraph, box: Box, fonts: Font[]): Frame {
 function layoutRow(segments: TextSegment[], box: Box) {
   const pos = { x: 0, y: 0 };
   const size = { width: 0, height: 0 };
+  let maxLineHeight = 0;
   const objects = [];
   segments.forEach((seg) => {
-    const { text, width, height, font, fontSize } = seg;
+    const { text, width, height, lineHeight, font, fontSize } = seg;
     const object: TextObject = { type: 'text', ...pos, text, font, fontSize };
     objects.push(object);
     pos.x += width;
     size.width += width;
     size.height = Math.max(size.height, height);
+    maxLineHeight = Math.max(maxLineHeight, height * lineHeight);
   });
-  const row = { type: 'row', x: box.x, y: box.y, ...size, objects };
-  return row;
+  return { type: 'row', x: box.x, y: box.y, width: size.width, height: maxLineHeight, objects };
 }

--- a/src/text.ts
+++ b/src/text.ts
@@ -4,11 +4,13 @@ import { Text, TextAttrs } from './content.js';
 import { Font, selectFont } from './fonts.js';
 
 const defaultFontSize = 18;
+const defaultLineHeight = 1.2;
 
 export type TextSegment = {
   text: string;
   width: number;
   height: number;
+  lineHeight: number;
   font: PDFFont;
   fontSize: number;
 };
@@ -38,13 +40,14 @@ function normalizeText(text: Text, attrs: TextAttrs): TextSpan[] {
 function measureSpans(spans: TextSpan[], fonts: Font[]): TextSegment[] {
   return spans.map((span) => {
     const { text, attrs } = span;
-    const { fontSize = defaultFontSize } = attrs;
+    const { fontSize = defaultFontSize, lineHeight = defaultLineHeight } = attrs;
     const font = selectFont(fonts, attrs);
     const height = font.heightAtSize(fontSize);
     return {
       text,
       width: font.widthOfTextAtSize(text, fontSize),
       height,
+      lineHeight,
       font,
       fontSize,
     };

--- a/test/layout.test.ts
+++ b/test/layout.test.ts
@@ -27,7 +27,7 @@ describe('layout', () => {
         ...{ type: 'page', ...box },
         children: [
           {
-            ...{ type: 'row', x: 0, y: 0, width: 162, height: 18 },
+            ...{ type: 'row', x: 0, y: 0, width: 162, height: 18 * 1.2 },
             objects: [
               { type: 'text', x: 0, y: 0, text: 'Test text', font: normalFont, fontSize: 18 },
             ],

--- a/test/text.test.ts
+++ b/test/text.test.ts
@@ -29,13 +29,14 @@ describe('text', () => {
           width: 54, // 3 * 18
           height: 18,
           fontSize: 18,
+          lineHeight: 1.2,
           font: normalFont,
         },
       ]);
     });
 
     it('respects global font attrs', () => {
-      const attrs = { fontSize: 10 };
+      const attrs = { fontSize: 10, lineHeight: 1.5 };
 
       const segments = extractTextSegments('foo', attrs, fonts);
 
@@ -44,26 +45,26 @@ describe('text', () => {
           width: 30, // 3 * 10
           height: 10,
           fontSize: 10,
+          lineHeight: 1.5,
         }),
       ]);
     });
 
     it('respects local font attrs', () => {
-      const attrs = { fontSize: 10 };
+      const attrs = { fontSize: 10, lineHeight: 1.5 };
 
       const segments = extractTextSegments({ text: 'foo', ...attrs }, {}, fonts);
 
       expect(segments).toEqual([
         objectContaining({
           fontSize: 10,
+          lineHeight: 1.5,
         }),
       ]);
     });
 
     it('returns multiple segments for multiple content parts', () => {
-      const attrs = { fontSize: 10 };
-
-      const segments = extractTextSegments(['foo', 'bar'], attrs, fonts);
+      const segments = extractTextSegments(['foo', 'bar'], {}, fonts);
 
       expect(segments).toEqual([
         objectContaining({ text: 'foo' }),


### PR DESCRIPTION
Running text is usually displayed with some space between the lines.
Hence, the line height is slightly larger than the font size.

CSS has a `line-height` attribute that allows to control the height of
text lines [[1]]. The default depends on the user agent, but is roughly
a factor of `1.2`, multiplied with the font size.

Introduce a text attribute `lineHeight` that supports a multiple of the
font size and defaults to `1.2`.

As in CSS, the line height can also be set on an inline element. In this
case, the height of a row is the maximum of the line heights of all
included text spans. Set this line height as the height of the "row"
frame.

Since the text baseline is currently set to the lower edge of the row,
the additional offset is added on top of each text row. This issue will
be addressed in a subsequent change, when the text baseline is adjusted
according to the font ascend and descend.

[1]: https://developer.mozilla.org/en-US/docs/Web/CSS/line-height