### PR TITLE
🔧 Cleanup TS config

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,12 @@
 {
   "compilerOptions": {
     "module": "ES6",
-    "target": "es6",
+    "target": "ES6",
     "outDir": "dist",
-    "sourceMap": true,
-    "lib": ["es2019"],
-    "declaration": true,
-    "noImplicitThis": true,
+    "lib": ["ES2019"],
     "moduleResolution": "Node",
-    "resolveJsonModule": true,
+    "sourceMap": true,
+    "declaration": true,
     "esModuleInterop": true,
     "incremental": true
   },
@@ -16,5 +14,5 @@
     "src/**/*.ts",
     "src/**/*.d.ts",
     "src/**/*.js"
-, "examples/pdf-lib-test.ts", "scripts/make.ts", "scripts/make-examples.js"  ]
+  ]
 }


### PR DESCRIPTION
Remove the unused directive `resolveJsonModule` from `tsconfig.json`.
Also remove `noImplicitThis`. There are no classes in this repository.

Remove outdated paths from the `includes` section.