### PR TITLE
✨ Support multi-line text

### DIFF
--- a/examples/sample.js
+++ b/examples/sample.js
@@ -14,8 +14,27 @@ export default {
   margin: { x: '2.5cm', top: '2cm', bottom: '1.5cm' },
   content: [
     { text: 'Lorem ipsum', bold: true, fontSize: 24, lineHeight: 1.5 },
-    { text: ['dolor sit amet, consectetur ', { text: 'adipiscing elit,', italic: true }] },
-    { text: 'sed do eiusmod tempor incididunt ut labore' },
-    { text: ['et ', { text: 'dolore magna', bold: true, italic: true }, ' aliqua.'] },
+    {
+      text: [
+        'dolor sit amet, consectetur ',
+        { text: 'adipiscing elit,', italic: true },
+        ' sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+      ],
+    },
+    {
+      text: [
+        'Ut enim ',
+        { text: 'ad minim veniam,', italic: true },
+        { text: ' quis nostrud', fontSize: 28 },
+        ' exercitation ullamco laboris nisi ',
+        {
+          text: ['ut aliquip', { text: ' ex ea commodo', italic: true }],
+        },
+        ' consequat.\n',
+        { text: 'Duis aute irure', bold: true },
+        ' dolor in reprehenderit in voluptate velit esse ',
+        'cillum dolore eu fugiat nulla pariatur.',
+      ],
+    },
   ],
 };

--- a/src/guides.ts
+++ b/src/guides.ts
@@ -23,6 +23,8 @@ function getColor(type: string) {
   switch (type) {
     case 'page':
       return rgb(1, 0, 0);
+    case 'paragraph':
+      return rgb(0, 0, 1);
     case 'row':
       return rgb(0, 0.5, 0);
     default:

--- a/src/text.ts
+++ b/src/text.ts
@@ -15,41 +15,161 @@ export type TextSegment = {
   fontSize: number;
 };
 
-export function extractTextSegments(text: Text, attrs: TextAttrs, fonts: Font[]): TextSegment[] {
-  return measureSpans(normalizeText(text, attrs), fonts);
-}
-
+/**
+ * A range of text with attributes, similar to a `<span>` in HTML.
+ */
 type TextSpan = {
   text: string;
   attrs: TextAttrs;
 };
 
-function normalizeText(text: Text, attrs: TextAttrs): TextSpan[] {
+export function parseText(text: Text, attrs: TextAttrs): TextSpan[] {
   if (Array.isArray(text)) {
-    return text.flatMap((text) => normalizeText(text, attrs));
+    return text.flatMap((text) => parseText(text, attrs));
   }
   if (typeof text === 'string') {
     return [{ text, attrs }];
   }
   if (typeof text === 'object' && 'text' in text) {
-    return normalizeText(text.text, { ...attrs, ...text });
+    return parseText(text.text, { ...attrs, ...extractAttrs(text) });
   }
   throw new TypeError(`Invalid text: ${text}`);
 }
 
-function measureSpans(spans: TextSpan[], fonts: Font[]): TextSegment[] {
-  return spans.map((span) => {
+function extractAttrs(object) {
+  const result: TextAttrs = {};
+  ['fontFamily', 'fontSize', 'lineHeight', 'bold', 'italic'].forEach((name) => {
+    if (name in object) result[name] = object[name];
+  });
+  return result;
+}
+
+export function extractTextSegments(textSpans: TextSpan[], fonts: Font[]): TextSegment[] {
+  return textSpans.flatMap((span) => {
     const { text, attrs } = span;
     const { fontSize = defaultFontSize, lineHeight = defaultLineHeight } = attrs;
     const font = selectFont(fonts, attrs);
     const height = font.heightAtSize(fontSize);
-    return {
+    return splitChunks(text).map((text) => ({
       text,
       width: font.widthOfTextAtSize(text, fontSize),
       height,
       lineHeight,
       font,
       fontSize,
-    };
+    }));
   });
+}
+
+/**
+ * Split the given text into chunks of subsequent whitespace (`\s`) and non-whitespace (`\S`)
+ * characters. For example, the string `foo bar` would be split into `['foo', ' ', 'bar']`.
+ * Newlines (`\n`) are preserved, each in a chunk of its own. Any whitespace that surrounds
+ * newlines is removed.
+ *
+ * @param text The input string
+ * @returns an array of chunks
+ */
+export function splitChunks(text: string): string[] {
+  const segments: string[] = [];
+  let tail = text;
+  let match = /\s+/.exec(tail);
+  while (match) {
+    if (match.index) {
+      segments.push(tail.slice(0, match.index));
+    }
+    const wsSegment = tail.slice(match.index, match.index + match[0].length);
+    const newlineCount = wsSegment.match(/\n/g)?.length;
+    if (newlineCount) {
+      segments.push(...'\n'.repeat(newlineCount).split(''));
+    } else {
+      segments.push(wsSegment);
+    }
+    tail = tail.slice(match.index + match[0].length);
+    match = /\s+/.exec(tail);
+  }
+  if (tail) {
+    segments.push(tail);
+  }
+  return segments;
+}
+
+export function breakLine(segments: TextSegment[], maxWidth: number) {
+  const breakIdx = findLinebreak(segments, maxWidth);
+  if (breakIdx >= 0) {
+    const head = segments.slice(0, breakIdx);
+    const tail = segments.slice(breakIdx + 1);
+    return tail.length ? [head, tail] : [head];
+  }
+  return [segments];
+}
+
+function findLinebreak(segments, maxWidth): number {
+  let x = 0;
+  for (const [idx, segment] of segments.entries()) {
+    const { text, width } = segment;
+    if (text === '\n') {
+      return idx;
+    }
+    x += width;
+    if (x > maxWidth) {
+      return findLinebreakOpportunity(segments, idx);
+    }
+  }
+}
+
+/**
+ * Finds the next appropriate segment that allows for a linebreak, starting at the given index, and
+ * returns its index.
+ *
+ * @param segments A list of text segments.
+ * @param index The index of the element to start at.
+ * @returns The index of the next segment that allows for linebreak if found, `undefined` otherwise.
+ */
+export function findLinebreakOpportunity(
+  segments: TextSegment[],
+  index: number
+): number | undefined {
+  // If the segment at the given index does not allow for a linebreak, look for a previous one.
+  for (let i = index; i >= 0; i--) {
+    if (isLineBreakOpportunity(segments[i])) {
+      return i;
+    }
+  }
+  // If no previous segment allows for a linebreak, find the next one after the index.
+  for (let i = index + 1; i < segments.length; i++) {
+    if (isLineBreakOpportunity(segments[i])) {
+      return i;
+    }
+  }
+}
+
+function isLineBreakOpportunity(segment: TextSegment): boolean {
+  return segment && /^\s+$/.test(segment.text);
+}
+
+/**
+ * Flatten a list of text segments by merging subsequent segments that have identical text
+ * attributes.
+ *
+ * @param segments a list of text segments
+ * @returns a possibly shorter list of text segments
+ */
+export function flattenTextSegments(segments: TextSegment[]): TextSegment[] {
+  const result: TextSegment[] = [];
+  let prev;
+  segments.forEach((segment) => {
+    if (
+      segment.font === prev?.font &&
+      segment.fontSize === prev?.fontSize &&
+      segment.lineHeight === prev?.lineHeight
+    ) {
+      prev.text += segment.text;
+      prev.width += segment.width;
+    } else {
+      prev = { ...segment };
+      result.push(prev);
+    }
+  });
+  return result;
 }

--- a/test/layout.test.ts
+++ b/test/layout.test.ts
@@ -18,7 +18,7 @@ describe('layout', () => {
       expect(frame).toEqual({ type: 'page', ...box, children: [] });
     });
 
-    it('returns a page with a single text row for single text content', () => {
+    it('returns a paragraph with a single text row for single text content', () => {
       const content = [{ text: 'Test text' }];
 
       const frame = layoutPage(content, box, fonts);
@@ -27,9 +27,14 @@ describe('layout', () => {
         ...{ type: 'page', ...box },
         children: [
           {
-            ...{ type: 'row', x: 0, y: 0, width: 162, height: 18 * 1.2 },
-            objects: [
-              { type: 'text', x: 0, y: 0, text: 'Test text', font: normalFont, fontSize: 18 },
+            ...{ type: 'paragraph', x: 0, y: 0, width: 162, height: 18 * 1.2 },
+            children: [
+              {
+                ...{ type: 'row', x: 0, y: 0, width: 162, height: 18 * 1.2 },
+                objects: [
+                  { type: 'text', x: 0, y: 0, text: 'Test text', font: normalFont, fontSize: 18 },
+                ],
+              },
             ],
           },
         ],

--- a/test/text.test.ts
+++ b/test/text.test.ts
@@ -1,6 +1,14 @@
 import { beforeEach, describe, expect, it } from '@jest/globals';
 
-import { extractTextSegments } from '../src/text.js';
+import {
+  breakLine,
+  extractTextSegments,
+  findLinebreakOpportunity,
+  flattenTextSegments,
+  parseText,
+  splitChunks,
+  TextSegment,
+} from '../src/text.js';
 import { fakeFont } from './test-utils.js';
 
 const { objectContaining } = expect;
@@ -13,17 +21,57 @@ describe('text', () => {
     [normalFont] = fonts.map((f) => f.pdfFont);
   });
 
-  describe('extractTextSegments', () => {
-    it('handles empty array', () => {
-      expect(extractTextSegments([], {}, fonts)).toEqual([]);
+  describe('parseText', () => {
+    it('accepts a string', () => {
+      const attrs = { italic: true };
+
+      expect(parseText('foo', attrs)).toEqual([{ text: 'foo', attrs }]);
     });
 
-    it('throws on invalid text content', () => {
-      expect(() => extractTextSegments([23 as any], {}, fonts)).toThrowError('Invalid text: 23');
+    it('accepts an object', () => {
+      const result = parseText({ text: 'foo', bold: true }, { italic: true });
+
+      expect(result).toEqual([{ text: 'foo', attrs: { italic: true, bold: true } }]);
+    });
+
+    it('accepts an array', () => {
+      const result = parseText([{ text: 'foo', bold: true }], { italic: true });
+
+      expect(result).toEqual([{ text: 'foo', attrs: { italic: true, bold: true } }]);
+    });
+
+    it('accepts empty array', () => {
+      expect(parseText([], {})).toEqual([]);
+    });
+
+    it('flattens nested structures', () => {
+      const input = [
+        { text: 'foo', bold: true },
+        { text: [{ text: 'bar' }] },
+        { text: { text: { text: 'baz', fontSize: 23 } } },
+      ];
+
+      const result = parseText(input, { italic: true });
+
+      expect(result).toEqual([
+        { text: 'foo', attrs: { italic: true, bold: true } },
+        { text: 'bar', attrs: { italic: true } },
+        { text: 'baz', attrs: { italic: true, fontSize: 23 } },
+      ]);
+    });
+
+    it('throws on invalid type', () => {
+      expect(() => parseText([23 as any], {})).toThrowError('Invalid text: 23');
+    });
+  });
+
+  describe('extractTextSegments', () => {
+    it('handles empty array', () => {
+      expect(extractTextSegments([], fonts)).toEqual([]);
     });
 
     it('returns segment with default attrs for single string', () => {
-      expect(extractTextSegments('foo', {}, fonts)).toEqual([
+      expect(extractTextSegments([{ text: 'foo', attrs: {} }], fonts)).toEqual([
         {
           text: 'foo',
           width: 54, // 3 * 18
@@ -38,7 +86,7 @@ describe('text', () => {
     it('respects global font attrs', () => {
       const attrs = { fontSize: 10, lineHeight: 1.5 };
 
-      const segments = extractTextSegments('foo', attrs, fonts);
+      const segments = extractTextSegments([{ text: 'foo', attrs }], fonts);
 
       expect(segments).toEqual([
         objectContaining({
@@ -53,7 +101,7 @@ describe('text', () => {
     it('respects local font attrs', () => {
       const attrs = { fontSize: 10, lineHeight: 1.5 };
 
-      const segments = extractTextSegments({ text: 'foo', ...attrs }, {}, fonts);
+      const segments = extractTextSegments([{ text: 'foo', attrs }], fonts);
 
       expect(segments).toEqual([
         objectContaining({
@@ -64,7 +112,13 @@ describe('text', () => {
     });
 
     it('returns multiple segments for multiple content parts', () => {
-      const segments = extractTextSegments(['foo', 'bar'], {}, fonts);
+      const segments = extractTextSegments(
+        [
+          { text: 'foo', attrs: {} },
+          { text: 'bar', attrs: {} },
+        ],
+        fonts
+      );
 
       expect(segments).toEqual([
         objectContaining({ text: 'foo' }),
@@ -72,4 +126,145 @@ describe('text', () => {
       ]);
     });
   });
+
+  describe('splitChunks', () => {
+    it('handles empty string', () => {
+      expect(splitChunks('')).toEqual([]);
+    });
+
+    it('handles single non-space', () => {
+      expect(splitChunks('a')).toEqual(['a']);
+    });
+
+    it('handles single space', () => {
+      expect(splitChunks(' ')).toEqual([' ']);
+    });
+
+    it('splits multiple non-spaces', () => {
+      expect(splitChunks('aaa')).toEqual(['aaa']);
+    });
+
+    it('splits multiple spaces', () => {
+      expect(splitChunks('   ')).toEqual(['   ']);
+    });
+
+    it('splits multiple spaces and non-spaces', () => {
+      expect(splitChunks('  aaa  bbb  ')).toEqual(['  ', 'aaa', '  ', 'bbb', '  ']);
+      expect(splitChunks('aaa  bbb  ccc')).toEqual(['aaa', '  ', 'bbb', '  ', 'ccc']);
+    });
+
+    it('splits newlines', () => {
+      expect(splitChunks('aaa\nbbb')).toEqual(['aaa', '\n', 'bbb']);
+      expect(splitChunks('aaa \n bbb')).toEqual(['aaa', '\n', 'bbb']);
+      expect(splitChunks('aaa \n \n bbb')).toEqual(['aaa', '\n', '\n', 'bbb']);
+    });
+  });
+
+  describe('findLinebreakOpportunity', () => {
+    it('handles empty array', () => {
+      expect(findLinebreakOpportunity([], 0)).toBeUndefined();
+      expect(findLinebreakOpportunity([], 1)).toBeUndefined();
+    });
+
+    it('handles exceeding index', () => {
+      expect(findLinebreakOpportunity([seg(' ')], -1)).toEqual(0);
+      expect(findLinebreakOpportunity([seg(' ')], 2)).toEqual(0);
+    });
+
+    it('returns index itself if it contains whitespace', () => {
+      expect(findLinebreakOpportunity([seg(' '), seg(' '), seg(' ')], 0)).toEqual(0);
+      expect(findLinebreakOpportunity([seg(' '), seg(' '), seg(' ')], 1)).toEqual(1);
+      expect(findLinebreakOpportunity([seg(' '), seg(' '), seg(' ')], 2)).toEqual(2);
+    });
+
+    it('returns previous opportunity', () => {
+      expect(findLinebreakOpportunity([seg(' '), seg('a'), seg(' ')], 1)).toEqual(0);
+      expect(findLinebreakOpportunity([seg(' '), seg(' '), seg('a')], 2)).toEqual(1);
+      expect(findLinebreakOpportunity([seg(' '), seg('a'), seg('a')], 2)).toEqual(0);
+    });
+
+    it('returns next opportunity if no previous one', () => {
+      expect(findLinebreakOpportunity([seg('a'), seg('a'), seg(' ')], 1)).toEqual(2);
+      expect(findLinebreakOpportunity([seg('a'), seg('a'), seg(' ')], 0)).toEqual(2);
+    });
+  });
+
+  describe('flattenTextSegments', () => {
+    it('handles empty array', () => {
+      expect(flattenTextSegments([])).toEqual([]);
+    });
+
+    it('merges subsequent segments if compatible', () => {
+      const segments = [seg('foo'), seg(' '), seg('bar')];
+
+      expect(flattenTextSegments(segments)).toEqual([seg('foo bar')]);
+    });
+
+    it('does not merge segments with different lineHeight', () => {
+      const segments = [seg('foo', { lineHeight: 1.5 }), seg('bar', { lineHeight: 1.3 })];
+
+      expect(flattenTextSegments(segments)).toEqual(segments);
+    });
+
+    it('does not merge adjacent segments if incompatible', () => {
+      const segments = [seg('foo', { fontSize: 11 }), seg('bar')];
+
+      expect(flattenTextSegments(segments)).toEqual(segments);
+    });
+
+    it('does not merge compatible segments if not adjacent', () => {
+      const segments = [seg('foo'), seg('-', { fontSize: 11 }), seg('bar')];
+
+      expect(flattenTextSegments(segments)).toEqual(segments);
+    });
+  });
+
+  describe('breakLine', () => {
+    it('handles empty array', () => {
+      expect(breakLine([], 10)).toEqual([[]]);
+    });
+
+    it('breaks at whitespace segment', () => {
+      const segments = [seg('aaa'), seg(' '), seg('bbb')];
+
+      expect(breakLine(segments, 30)).toEqual([[seg('aaa')], [seg('bbb')]]);
+      expect(breakLine(segments, 40)).toEqual([[seg('aaa')], [seg('bbb')]]);
+      expect(breakLine(segments, 50)).toEqual([[seg('aaa')], [seg('bbb')]]);
+    });
+
+    it('breaks at newline segment', () => {
+      const segments = [seg('aaa'), seg('\n'), seg('bbb')];
+
+      expect(breakLine(segments, 30)).toEqual([[seg('aaa')], [seg('bbb')]]);
+      expect(breakLine(segments, 40)).toEqual([[seg('aaa')], [seg('bbb')]]);
+      expect(breakLine(segments, 80)).toEqual([[seg('aaa')], [seg('bbb')]]);
+    });
+
+    it('keeps unbreakable text on same line', () => {
+      const segments = [seg('aaa'), seg(' '), seg('bbb')];
+
+      expect(breakLine(segments, 20)).toEqual([[seg('aaa')], [seg('bbb')]]);
+    });
+
+    it('keeps unbreakable text on same line (with newline)', () => {
+      const segments = [seg('aaa'), seg('\n'), seg('bbb')];
+
+      expect(breakLine(segments, 20)).toEqual([[seg('aaa')], [seg('bbb')]]);
+    });
+
+    it('removes leading whitespace before line break', () => {
+      const segments = [seg(' '), seg('aaa')];
+
+      expect(breakLine(segments, 0)).toEqual([[], [seg('aaa')]]);
+      expect(breakLine(segments, 10)).toEqual([[], [seg('aaa')]]);
+      expect(breakLine(segments, 30)).toEqual([[], [seg('aaa')]]);
+      expect(breakLine(segments, 40)).toEqual([[seg(' '), seg('aaa')]]);
+    });
+  });
 });
+
+function seg(text: string, attrs?): TextSegment {
+  const { font, fontSize = 10, height = 12, lineHeight = 14 } = attrs ?? {};
+  const width = text.length * fontSize;
+  return { text, width, height, lineHeight, font, fontSize };
+}


### PR DESCRIPTION
Each element in the document's `content` array is a paragraph.
When the text of a paragraph does not fit into a single line, it should
be broken into multiple lines.

This change implements a line-breaking algorithm that first splits text
into chunks of subsequent whitespace and non-whitespace characters and
measures these chunks separately. When trying to fit the chunks into a
given box, chunks of whitespace characters represent an opportunity for
a line break. When a chunks exceeds the max width, a line break is made
before that chunk, or, if that is not possible, after the exceeding
chunk. This ensures that text is rendered even when no line break is
possible. In this case, text will exceeds the margin.

A "paragraph" frame is introduced, that includes all rows of a
paragraph.