### PR TITLE
✨ Support padding and margin on paragraphs

### DIFF
--- a/examples/sample.js
+++ b/examples/sample.js
@@ -20,13 +20,15 @@ export default {
   },
   margin: { x: '2.5cm', top: '2cm', bottom: '1.5cm' },
   content: [
-    { text: 'Lorem ipsum', bold: true, fontSize: 24, lineHeight: 1.5 },
+    { text: 'Lorem ipsum', bold: true, fontSize: 24, margin: { bottom: 10 } },
     {
       text: [
         'dolor sit amet, consectetur ',
         { text: 'adipiscing elit,', italic: true },
         ' sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
       ],
+      lineHeight: 1.5,
+      margin: { y: 5 },
     },
     {
       text: [
@@ -42,6 +44,8 @@ export default {
         ' dolor in reprehenderit in voluptate velit esse ',
         'cillum dolore eu fugiat nulla pariatur.',
       ],
+      padding: { left: '5mm' },
+      margin: { y: 5 },
     },
   ],
 };

--- a/src/content.ts
+++ b/src/content.ts
@@ -81,6 +81,16 @@ export type Paragraph = {
    * Text to display in this paragraph.
    */
   text?: Text;
+  /**
+   * Space to leave between the contents of a paragraph and its edges.
+   */
+  padding?: Length | BoxLengths;
+  /**
+   * Space to surround the paragraph.
+   * The `top` and `bottom` margins of adjacent paragraphs are collapsed into a single margin
+   * whose size is the maximum of the two margins.
+   */
+  margin?: Length | BoxLengths;
 } & TextAttrs;
 
 /**

--- a/test/layout.test.ts
+++ b/test/layout.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it } from '@jest/globals';
 import { layoutPage } from '../src/layout.js';
 import { fakeFont } from './test-utils.js';
 
+const { objectContaining } = expect;
+
 describe('layout', () => {
   let fonts, normalFont, box;
 
@@ -11,6 +13,7 @@ describe('layout', () => {
     [normalFont] = fonts.map((f) => f.pdfFont);
     box = { x: 20, y: 30, width: 400, height: 700 };
   });
+
   describe('layoutPage', () => {
     it('returns empty page frame for empty content', () => {
       const frame = layoutPage([], box, fonts);
@@ -27,7 +30,7 @@ describe('layout', () => {
         ...{ type: 'page', ...box },
         children: [
           {
-            ...{ type: 'paragraph', x: 0, y: 0, width: 162, height: 18 * 1.2 },
+            ...{ type: 'paragraph', x: 0, y: 0, width: 400, height: 18 * 1.2 },
             children: [
               {
                 ...{ type: 'row', x: 0, y: 0, width: 162, height: 18 * 1.2 },
@@ -39,6 +42,35 @@ describe('layout', () => {
           },
         ],
       });
+    });
+
+    it('includes padding around text in paragraph', () => {
+      const content = [
+        { text: 'foo', padding: { left: 1, right: 2, top: 3, bottom: 4 }, fontSize: 10 },
+      ];
+
+      const frame = layoutPage(content, box, fonts);
+
+      expect(frame.children).toEqual([
+        objectContaining({ type: 'paragraph', x: 0, y: 0, width: 400, height: 12 + 3 + 4 }),
+      ]);
+      expect(frame.children[0].children).toEqual([
+        objectContaining({ type: 'row', x: 1, y: 3, width: 30, height: 12 }),
+      ]);
+    });
+
+    it('surrounds paragraphs with margins', () => {
+      const content = [
+        { text: 'foo', margin: { left: 1, right: 2, top: 3, bottom: 4 }, fontSize: 10 },
+        { text: 'bar', margin: { left: 5, right: 6, top: 7, bottom: 8 }, fontSize: 10 },
+      ];
+
+      const frame = layoutPage(content, box, fonts);
+
+      expect(frame.children).toEqual([
+        objectContaining({ type: 'paragraph', x: 1, y: 3, width: 400 - 1 - 2, height: 12 }),
+        objectContaining({ type: 'paragraph', x: 5, y: 3 + 12 + 7, width: 400 - 5 - 6 }),
+      ]);
     });
   });
 });


### PR DESCRIPTION
This change adds support for the attributes `padding` and `margin` on
paragraphs.

As in the [CSS box model], a padding adds space between the edges of a
paragraph and its contents, while a margin surrounds a paragraph and
provides space between paragraphs.

Adjacent margins collapse into one, i.e. the bottom margin of one
paragraph is merged with the top margin of the next paragraph into a
single margin whose size is the maximum of the two margins.
This is also a feature of the [CSS box model].

Instead of shrinking the width of paragraphs to their content width,
set it to its available width. This allows for testing the effect of
margins, but it's also a precondition for right and center alignment.

[CSS box model]: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Box_Model