### PR TITLE
✨ Support drawing rectangles, lines, and polylines

### DIFF
--- a/examples/sample.js
+++ b/examples/sample.js
@@ -48,5 +48,39 @@ export default {
       padding: { left: '5mm' },
       margin: { y: 5 },
     },
+    {
+      text: 'Text and graphics',
+      graphics: [
+        {
+          type: 'rect',
+          x: -15,
+          y: 0,
+          width: 10,
+          height: 20,
+          fillColor: 'red',
+        },
+        { type: 'line', x1: 0, y1: 30, x2: 150, y2: 30, strokeWidth: 0.5, strokeColor: '#239842' },
+      ],
+      padding: { left: 15, top: 5, bottom: 15 },
+      margin: { y: 5 },
+    },
+    {
+      graphics: [
+        {
+          type: 'polyline',
+          strokeWidth: 2,
+          fillColor: '#4488cc',
+          strokeColor: 'white',
+          points: [
+            { x: 100, y: 10 },
+            { x: 40, y: 198 },
+            { x: 190, y: 78 },
+            { x: 10, y: 78 },
+            { x: 160, y: 198 },
+          ],
+          closePath: true,
+        },
+      ],
+    },
   ],
 };

--- a/src/content.ts
+++ b/src/content.ts
@@ -84,6 +84,12 @@ export type Paragraph = {
    */
   text?: Text;
   /**
+   * Graphic elements to draw in the area covered by the paragraph.
+   * The coordinate system for graphics shapes starts at the top left corner of the paragraph's
+   * padding.
+   */
+  graphics?: Shape[];
+  /**
    * Space to leave between the contents of a paragraph and its edges.
    */
   padding?: Length | BoxLengths;
@@ -94,6 +100,38 @@ export type Paragraph = {
    */
   margin?: Length | BoxLengths;
 } & TextAttrs;
+
+export type Shape = Rect | Line | Polyline;
+
+export type Rect = {
+  type: 'rect';
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  strokeWidth?: number;
+  strokeColor?: Color;
+  fillColor?: Color;
+};
+
+export type Line = {
+  type: 'line';
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  strokeWidth?: number;
+  strokeColor?: Color;
+};
+
+export type Polyline = {
+  type: 'polyline';
+  points: { x: number; y: number }[];
+  closePath?: boolean;
+  strokeWidth?: number;
+  strokeColor?: Color;
+  fillColor?: Color;
+};
 
 /**
  * A piece of inline text. A list can be used to apply styles to parts of a paragraph.

--- a/src/graphics.ts
+++ b/src/graphics.ts
@@ -1,0 +1,187 @@
+import { Pos } from './box.js';
+import { Color, parseColor } from './colors.js';
+
+export type GraphicsObject = RectObject | LineObject | PolylineObject;
+
+export type RectObject = {
+  type: 'rect';
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  strokeWidth?: number;
+  strokeColor?: Color;
+  fillColor?: Color;
+};
+
+export type LineObject = {
+  type: 'line';
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  strokeWidth?: number;
+  strokeColor?: Color;
+};
+
+export type PolylineObject = {
+  type: 'polyline';
+  points: { x: number; y: number }[];
+  closePath?: boolean;
+  strokeWidth?: number;
+  strokeColor?: Color;
+  fillColor?: Color;
+};
+
+type Obj = Record<string, unknown>;
+
+/**
+ * Parses a given input as a graphics shape object. Throws if the input cannot be parsed.
+ *
+ * @param input The input value to parse.
+ * @returns A graphics shape object.
+ */
+export function parseGraphicsObject(input: unknown): GraphicsObject {
+  if (typeof input !== 'object') throw new TypeError(`Invalid graphics object: ${input}`);
+  const shape = input as Obj;
+  try {
+    switch (shape.type) {
+      case 'rect':
+        return parseRect(shape);
+      case 'line':
+        return parseLine(shape);
+      case 'polyline':
+        return parsePolyline(shape);
+    }
+  } catch (error) {
+    throw new TypeError(`Invalid graphics object of type ${shape.type}: ${error.message}`);
+  }
+  throw new TypeError(`Unsupported graphics object type: ${shape.type}`);
+}
+
+function parseRect(input: Obj): RectObject {
+  return {
+    type: 'rect',
+    x: pickNumber(input, 'x'),
+    y: pickNumber(input, 'y'),
+    width: pickNumber(input, 'width'),
+    height: pickNumber(input, 'height'),
+    strokeWidth: pickNumber(input, 'strokeWidth', { optional: true, predicate: (n) => n >= 0 }),
+    strokeColor: pickColor(input, 'strokeColor', { optional: true }),
+    fillColor: pickColor(input, 'fillColor', { optional: true }),
+  };
+}
+
+function parseLine(input: Obj): LineObject {
+  return {
+    type: 'line',
+    x1: pickNumber(input, 'x1'),
+    x2: pickNumber(input, 'x2'),
+    y1: pickNumber(input, 'y1'),
+    y2: pickNumber(input, 'y2'),
+    strokeWidth: pickNumber(input, 'strokeWidth', { optional: true, predicate: (n) => n >= 0 }),
+    strokeColor: pickColor(input, 'strokeColor', { optional: true }),
+  };
+}
+
+function parsePolyline(input: Obj): PolylineObject {
+  return {
+    type: 'polyline',
+    points: pickPoints(input, 'points'),
+    closePath: pickBoolean(input, 'closePath', { optional: true }),
+    strokeWidth: pickNumber(input, 'strokeWidth', { optional: true, predicate: (n) => n >= 0 }),
+    strokeColor: pickColor(input, 'strokeColor', { optional: true }),
+    fillColor: pickColor(input, 'fillColor', { optional: true }),
+  };
+}
+
+/**
+ * Shifts the a graphics object to a given position by adding the position's `x` and `y` values
+ * to the coordinates of the graphics object.
+ *
+ * @param rect The input graphics object to shift
+ * @param pos The position to shift to
+ * @returns The new graphics object
+ */
+export function shiftGraphicsObject<T extends GraphicsObject>(shape: T, pos: Pos): T {
+  switch (shape.type) {
+    case 'rect':
+      return shiftRect(shape, pos) as T;
+    case 'line':
+      return shiftLine(shape, pos) as T;
+    case 'polyline':
+      return shiftPolyline(shape, pos) as T;
+  }
+}
+
+function shiftRect(rect: RectObject, pos: Pos): RectObject {
+  return { ...rect, x: rect.x + pos.x, y: rect.y + pos.y };
+}
+
+function shiftLine(line: LineObject, pos: Pos): LineObject {
+  return {
+    ...line,
+    x1: line.x1 + pos.x,
+    x2: line.x2 + pos.x,
+    y1: line.y1 + pos.y,
+    y2: line.y2 + pos.y,
+  };
+}
+
+function shiftPolyline(polyline: PolylineObject, pos: Pos): PolylineObject {
+  return {
+    ...polyline,
+    points: polyline.points.map((p) => ({ x: p.x + pos.x, y: p.y + pos.y })),
+  };
+}
+
+function pickNumber(
+  input: Obj,
+  name: string,
+  options?: { optional?: boolean; predicate?: (number) => boolean }
+): number {
+  const { optional, predicate } = options ?? {};
+  const value = input[name];
+  if (value == null) {
+    if (optional) return undefined;
+    throw new TypeError(`Missing value for ${name}`);
+  }
+  if (!Number.isFinite(value)) throw new TypeError(`Invalid value for ${name}: ${value}`);
+  if (predicate && !predicate(value)) throw new TypeError(`Invalid value for ${name}: ${value}`);
+  return value as number;
+}
+
+function pickBoolean(input: Obj, name: string, options?: { optional?: boolean }): boolean {
+  const { optional } = options ?? {};
+  const value = input[name];
+  if (value == null) {
+    if (optional) return undefined;
+    throw new TypeError(`Missing value for ${name}`);
+  }
+  if (typeof value !== 'boolean') throw new TypeError(`Invalid value for ${name}: ${value}`);
+  return value;
+}
+
+function pickColor(input: Obj, name: string, options?: { optional?: boolean }): Color {
+  const { optional } = options ?? {};
+  const value = input[name];
+  if (value == null) {
+    if (optional) return undefined;
+    throw new TypeError(`Missing value for ${name}`);
+  }
+  return parseColor(value);
+}
+
+function pickPoints(input: Obj, name: string): { x: number; y: number }[] {
+  const value = input[name];
+  if (value == null) throw new TypeError(`Missing value for ${name}`);
+  if (!Array.isArray(value)) throw new TypeError(`Invalid value for ${name}: ${value}`);
+  try {
+    return value.map((point) => ({
+      x: pickNumber(point, 'x'),
+      y: pickNumber(point, 'y'),
+    })) as { x: number; y: number }[];
+  } catch (error) {
+    throw new TypeError(`Invalid point in ${name}: ${error.message}`);
+  }
+}

--- a/src/page.ts
+++ b/src/page.ts
@@ -1,7 +1,15 @@
-import { PDFDocument, PDFPage, PDFPageDrawTextOptions } from 'pdf-lib';
+import {
+  PDFDocument,
+  PDFPage,
+  PDFPageDrawLineOptions,
+  PDFPageDrawRectangleOptions,
+  PDFPageDrawSVGOptions,
+  PDFPageDrawTextOptions,
+} from 'pdf-lib';
 
 import { BoxEdges, parseEdges, Pos, Size } from './box.js';
 import { DocumentDefinition } from './content.js';
+import { LineObject, PolylineObject, RectObject } from './graphics.js';
 import { renderGuide } from './guides.js';
 import { Frame, TextObject } from './layout.js';
 
@@ -30,13 +38,22 @@ export function renderFrame(frame: Frame, page: Page, base: Pos = null) {
   const topLeft = { x: frame.x + (base?.x ?? 0), y: frame.y + (base?.y ?? 0) };
   const bottomLeft = { x: topLeft.x, y: topLeft.y + height };
   renderGuide(page, { ...tr(bottomLeft, page), width, height }, frame.type);
-  frame.children?.forEach((frame) => {
-    renderFrame(frame, page, topLeft);
-  });
   frame.objects?.forEach((object) => {
     if (object.type === 'text') {
       renderText(object, page, bottomLeft);
     }
+    if (object.type === 'rect') {
+      renderRect(object, page, topLeft);
+    }
+    if (object.type === 'line') {
+      renderLine(object, page, topLeft);
+    }
+    if (object.type === 'polyline') {
+      renderPolyline(object, page, topLeft);
+    }
+  });
+  frame.children?.forEach((frame) => {
+    renderFrame(frame, page, topLeft);
   });
 }
 
@@ -45,6 +62,41 @@ function renderText(el: TextObject, page: Page, base: Pos) {
   const options: PDFPageDrawTextOptions = { x, y, size: el.fontSize, font: el.font };
   if (el.color) options.color = el.color;
   page.pdfPage.drawText(el.text, options);
+}
+
+function renderRect(rect: RectObject, page: Page, base: Pos) {
+  const { x, y } = tr({ x: rect.x + base.x, y: rect.y + base.y + rect.height }, page);
+  const { width, height } = rect;
+  const options: PDFPageDrawRectangleOptions = { x, y, width, height };
+  if ('strokeColor' in rect) options.borderColor = rect.strokeColor;
+  if ('strokeWidth' in rect) options.borderWidth = rect.strokeWidth;
+  if ('fillColor' in rect) options.color = rect.fillColor;
+  page.pdfPage.drawRectangle(options);
+}
+
+function renderLine(line: LineObject, page: Page, base: Pos) {
+  const options: PDFPageDrawLineOptions = {
+    start: tr({ x: line.x1 + base.x, y: line.y1 + base.y }, page),
+    end: tr({ x: line.x2 + base.x, y: line.y2 + base.y }, page),
+  };
+  if ('strokeWidth' in line) options.thickness = line.strokeWidth;
+  if ('strokeColor' in line) options.color = line.strokeColor;
+  page.pdfPage.drawLine(options);
+}
+
+function renderPolyline(polyline: PolylineObject, page: Page, base: Pos) {
+  const path = createSvgPath(polyline.points, polyline.closePath);
+  const { x, y } = tr(base, page);
+  const options: PDFPageDrawSVGOptions = { x, y };
+  if ('strokeColor' in polyline) options.borderColor = polyline.strokeColor;
+  if ('strokeWidth' in polyline) options.borderWidth = polyline.strokeWidth;
+  if ('fillColor' in polyline) options.color = polyline.fillColor;
+  page.pdfPage.drawSvgPath(path, options);
+}
+
+function createSvgPath(points: { x: number; y: number }[], closePath = false): string {
+  const z = closePath ? ' Z' : '';
+  return points.reduce((s, p) => (s ? `${s} L` : `M`) + `${p.x},${p.y}`, '') + z;
 }
 
 function tr(pos: Pos, page: Page): Pos {

--- a/test/graphics.test.ts
+++ b/test/graphics.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from '@jest/globals';
+import { rgb } from 'pdf-lib';
+
+import {
+  LineObject,
+  parseGraphicsObject,
+  PolylineObject,
+  RectObject,
+  shiftGraphicsObject,
+} from '../src/graphics.js';
+
+describe('graphics', () => {
+  describe('parseGraphicsObject', () => {
+    it('throws for invalid types', () => {
+      expect(() => parseGraphicsObject(23)).toThrowError('Invalid graphics object: 23');
+      expect(() => parseGraphicsObject('foo')).toThrowError('Invalid graphics object: foo');
+    });
+
+    it('throws for unsupported type attribute', () => {
+      const fn = () => parseGraphicsObject({ type: 'foo' });
+
+      expect(fn).toThrowError('Unsupported graphics object type: foo');
+    });
+
+    it('parses rect object', () => {
+      const rect = {
+        ...{ type: 'rect', x: 1, y: 2, width: 10, height: 20 },
+        strokeWidth: 1.5,
+        strokeColor: 'red',
+        fillColor: 'blue',
+      };
+
+      expect(parseGraphicsObject(rect)).toEqual({
+        ...rect,
+        strokeColor: rgb(1, 0, 0),
+        fillColor: rgb(0, 0, 1),
+      });
+    });
+
+    ['x', 'y', 'width', 'height'].forEach((name) => {
+      it(`throws for missing rect attribute ${name}`, () => {
+        const rect = { type: 'rect', x: 1, y: 2, width: 10, height: 20 };
+        delete rect[name];
+
+        const fn = () => parseGraphicsObject(rect);
+
+        expect(fn).toThrowError(`Invalid graphics object of type rect: Missing value for ${name}`);
+      });
+    });
+
+    it('parses line object', () => {
+      const line = {
+        ...{ type: 'line', x1: 1, y1: 2, x2: 11, y2: 12 },
+        strokeWidth: 1.5,
+        strokeColor: 'red',
+      };
+
+      expect(parseGraphicsObject(line)).toEqual({
+        ...line,
+        strokeColor: rgb(1, 0, 0),
+      });
+    });
+
+    ['x1', 'y1', 'x2', 'y2'].forEach((name) => {
+      it(`throws for missing line attribute ${name}`, () => {
+        const line = { type: 'line', x1: 1, y1: 2, x2: 11, y2: 12 };
+        delete line[name];
+
+        const fn = () => parseGraphicsObject(line);
+
+        expect(fn).toThrowError(`Invalid graphics object of type line: Missing value for ${name}`);
+      });
+    });
+
+    it('parses polyline object', () => {
+      const polyline = {
+        ...{ type: 'polyline', points: [p(1, 2), p(3, 4)] },
+        strokeWidth: 1.5,
+        strokeColor: 'red',
+        fillColor: 'blue',
+      };
+
+      expect(parseGraphicsObject(polyline)).toEqual({
+        ...polyline,
+        strokeColor: rgb(1, 0, 0),
+        fillColor: rgb(0, 0, 1),
+      });
+    });
+
+    it(`throws for missing polyline attribute points`, () => {
+      const fn = () => parseGraphicsObject({ type: 'polyline' });
+
+      expect(fn).toThrowError(`Invalid graphics object of type polyline: Missing value for points`);
+    });
+
+    ['strokeColor', 'fillColor'].forEach((name) => {
+      it(`throws for invalid rect attribute ${name}`, () => {
+        const rect = { type: 'rect', x: 1, y: 2, width: 10, height: 20, [name]: 'foo' };
+
+        const fn = () => parseGraphicsObject(rect);
+
+        expect(fn).toThrowError(
+          `Invalid graphics object of type rect: Unsupported color name: 'foo'`
+        );
+      });
+    });
+
+    it(`throws for negative value in attribute strokeWidth`, () => {
+      const rect = { type: 'rect', x: 1, y: 2, width: 10, height: 20, strokeWidth: -1 };
+
+      const fn = () => parseGraphicsObject(rect);
+
+      expect(fn).toThrowError(
+        `Invalid graphics object of type rect: Invalid value for strokeWidth: -1`
+      );
+    });
+  });
+
+  describe('shiftGraphicsObject', () => {
+    it('shifts rect', () => {
+      const rect: RectObject = { type: 'rect', x: 1, y: 2, width: 30, height: 40 };
+
+      const shifted = shiftGraphicsObject(rect, { x: 5, y: 6 });
+
+      expect(shifted).toEqual({ type: 'rect', x: 6, y: 8, width: 30, height: 40 });
+    });
+
+    it('shifts line', () => {
+      const line: LineObject = { type: 'line', x1: 1, y1: 2, x2: 11, y2: 12 };
+
+      const shifted = shiftGraphicsObject(line, { x: 5, y: 6 });
+
+      expect(shifted).toEqual({ type: 'line', x1: 6, y1: 8, x2: 16, y2: 18 });
+    });
+
+    it('shifts polyline', () => {
+      const polyline: PolylineObject = { type: 'polyline', points: [p(1, 2), p(3, 4)] };
+
+      const shifted = shiftGraphicsObject(polyline, { x: 5, y: 6 });
+
+      expect(shifted).toEqual({ type: 'polyline', points: [p(6, 8), p(8, 10)] });
+    });
+  });
+});
+
+function p(x, y) {
+  return { x, y };
+}

--- a/test/layout.test.ts
+++ b/test/layout.test.ts
@@ -72,5 +72,53 @@ describe('layout', () => {
         objectContaining({ type: 'paragraph', x: 5, y: 3 + 12 + 7, width: 400 - 5 - 6 }),
       ]);
     });
+
+    it('includes graphics objects in child frame', () => {
+      const graphics = [
+        { type: 'line', x1: 1, y1: 2, x2: 3, y2: 4 },
+        { type: 'rect', x: 1, y: 2, width: 10, height: 20 },
+        { type: 'polyline', points: [p(1, 2), p(3, 4)] },
+      ] as any;
+
+      const frame = layoutPage([{ graphics }], box, fonts);
+
+      expect(frame).toEqual(objectContaining({ type: 'page', ...box }));
+      expect(frame.children).toEqual([
+        objectContaining({
+          ...{ type: 'paragraph', x: 0, y: 0, width: 400, height: 0 },
+          objects: [
+            { type: 'line', x1: 1, y1: 2, x2: 3, y2: 4 },
+            { type: 'rect', x: 1, y: 2, width: 10, height: 20 },
+            { type: 'polyline', points: [p(1, 2), p(3, 4)] },
+          ],
+        }),
+      ]);
+    });
+
+    it('applies padding to graphics objects', () => {
+      const graphics = [
+        { type: 'line', x1: 1, y1: 2, x2: 3, y2: 4 },
+        { type: 'rect', x: 1, y: 2, width: 10, height: 20 },
+        { type: 'polyline', points: [p(1, 2), p(3, 4)] },
+      ] as any;
+
+      const frame = layoutPage([{ graphics, padding: 5 }], box, fonts);
+
+      expect(frame).toEqual(objectContaining({ type: 'page', ...box }));
+      expect(frame.children).toEqual([
+        objectContaining({
+          ...{ type: 'paragraph', x: 0, y: 0, width: 400, height: 10 },
+          objects: [
+            { type: 'line', x1: 6, y1: 7, x2: 8, y2: 9 },
+            { type: 'rect', x: 6, y: 7, width: 10, height: 20 },
+            { type: 'polyline', points: [p(6, 7), p(8, 9)] },
+          ],
+        }),
+      ]);
+    });
   });
 });
+
+function p(x: number, y: number) {
+  return { x, y };
+}

--- a/test/page.test.ts
+++ b/test/page.test.ts
@@ -50,6 +50,9 @@ describe('page', () => {
           context: PDFContext.create(),
         },
         drawText: jest.fn(),
+        drawLine: jest.fn(),
+        drawRectangle: jest.fn(),
+        drawSvgPath: jest.fn(),
       };
       page = { size, pdfPage };
       font = fakePdfFont('Test');
@@ -64,8 +67,8 @@ describe('page', () => {
       renderFrame(frame, page);
 
       expect(pdfPage.drawText).toHaveBeenCalledWith('Test text', {
-        x: 11, // 10 + 1
-        y: 748, // 800 - 20 - 2 - 30
+        x: 10 + 1,
+        y: 800 - 20 - 2 - 30,
         size: 12,
         font,
       });
@@ -104,11 +107,138 @@ describe('page', () => {
       renderFrame(frame, page);
 
       expect(pdfPage.drawText).toHaveBeenCalledWith('Test text', {
-        x: 21, // 10 + 10 + 1
-        y: 728, // 800 - 20 - 20 - 2 - 30
+        x: 10 + 10 + 1,
+        y: 800 - 20 - 20 - 2 - 30,
         size: 12,
         font,
       });
     });
+
+    it('renders rect objects', () => {
+      const frame: Frame = {
+        ...{ x: 10, y: 20, width: 200, height: 30 },
+        objects: [{ type: 'rect', x: 1, y: 2, width: 3, height: 4 }],
+      };
+
+      renderFrame(frame, page);
+
+      expect(pdfPage.drawRectangle).toHaveBeenCalledWith({
+        x: 10 + 1,
+        y: 800 - 20 - 2 - 4,
+        width: 3,
+        height: 4,
+      });
+    });
+
+    it('renders rect objects with style attrs', () => {
+      const frame: Frame = {
+        ...{ x: 10, y: 20, width: 200, height: 30 },
+        objects: [
+          {
+            ...{ type: 'rect', x: 1, y: 2, width: 3, height: 4 },
+            strokeColor: rgb(1, 0, 0),
+            strokeWidth: 1,
+            fillColor: rgb(0, 0, 1),
+          },
+        ],
+      };
+
+      renderFrame(frame, page);
+
+      expect(pdfPage.drawRectangle).toHaveBeenCalledWith(
+        objectContaining({
+          borderColor: rgb(1, 0, 0),
+          borderWidth: 1,
+          color: rgb(0, 0, 1),
+        })
+      );
+    });
+
+    it('renders line objects', () => {
+      const frame: Frame = {
+        ...{ x: 10, y: 20, width: 200, height: 30 },
+        objects: [{ type: 'line', x1: 1, y1: 2, x2: 3, y2: 4 }],
+      };
+
+      renderFrame(frame, page);
+
+      expect(pdfPage.drawLine).toHaveBeenCalledWith({
+        start: { x: 10 + 1, y: 800 - 20 - 2 },
+        end: { x: 10 + 3, y: 800 - 20 - 4 },
+      });
+    });
+
+    it('renders line objects with style attrs', () => {
+      const frame: Frame = {
+        ...{ x: 10, y: 20, width: 200, height: 30 },
+        objects: [
+          {
+            ...{ type: 'line', x1: 1, y1: 2, x2: 3, y2: 4 },
+            strokeWidth: 1,
+            strokeColor: rgb(1, 0, 0),
+          },
+        ],
+      };
+
+      renderFrame(frame, page);
+
+      expect(pdfPage.drawLine).toHaveBeenCalledWith(
+        objectContaining({
+          thickness: 1,
+          color: rgb(1, 0, 0),
+        })
+      );
+    });
+
+    it('renders polyline objects', () => {
+      const frame: Frame = {
+        ...{ x: 10, y: 20, width: 200, height: 30 },
+        objects: [{ type: 'polyline', points: [p(1, 2), p(3, 4)] }],
+      };
+
+      renderFrame(frame, page);
+
+      expect(pdfPage.drawSvgPath).toHaveBeenCalledWith('M1,2 L3,4', { x: 10, y: 800 - 20 });
+    });
+
+    it('renders polyline objects with closePath', () => {
+      const frame: Frame = {
+        ...{ x: 10, y: 20, width: 200, height: 30 },
+        objects: [{ type: 'polyline', points: [p(1, 2), p(3, 4)], closePath: true }],
+      };
+
+      renderFrame(frame, page);
+
+      expect(pdfPage.drawSvgPath).toHaveBeenCalledWith('M1,2 L3,4 Z', expect.anything());
+    });
+
+    it('renders polyline objects with style attrs', () => {
+      const frame: Frame = {
+        ...{ x: 10, y: 20, width: 200, height: 30 },
+        objects: [
+          {
+            ...{ type: 'polyline', points: [p(1, 2), p(3, 4)] },
+            strokeColor: rgb(1, 0, 0),
+            strokeWidth: 1,
+            fillColor: rgb(0, 0, 1),
+          },
+        ],
+      };
+
+      renderFrame(frame, page);
+
+      expect(pdfPage.drawSvgPath).toHaveBeenCalledWith(
+        expect.anything(),
+        objectContaining({
+          borderColor: rgb(1, 0, 0),
+          borderWidth: 1,
+          color: rgb(0, 0, 1),
+        })
+      );
+    });
   });
 });
+
+function p(x, y) {
+  return { x, y };
+}


### PR DESCRIPTION
To allow drawing basic graphics shapes into paragraphs, e.g. for markers
or annotations, this change introduces a new attribute `graphics` in
paragraph objects. This attribute accepts an array of graphics objects.
Supported types of graphics objects are `rect`, `line`, and `polyline`.

The coordinates of graphics objects are interpreted relative to the
padding of the paragraph. The origin of the coordinate system is the
top left corner, similar to [SVG] and the [Canvas API].

Parse the graphics objects before processing to ensure that no invalid
attributes can lead to unexpected errors during layout and render.
The parse function picks only the relevant members of a given object and
check their types.

Graphics objects are included in the paragraph frame's `objects`. Render
the drawable objects of a frame before child frames to draw text on top
of drawings.

[SVG]: https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Positions
[Canvas API]: https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API