### PR TITLE
✨ Support text alignment

### DIFF
--- a/examples/sample.js
+++ b/examples/sample.js
@@ -23,7 +23,13 @@ export default {
     fontSize: 14,
   },
   content: [
-    { text: 'Lorem ipsum', bold: true, fontSize: 24, margin: { bottom: 10 } },
+    {
+      text: 'Lorem ipsum',
+      bold: true,
+      fontSize: 24,
+      margin: { bottom: 10 },
+      textAlign: 'center',
+    },
     {
       text: [
         'dolor sit amet, consectetur ',

--- a/src/content.ts
+++ b/src/content.ts
@@ -103,6 +103,11 @@ export type Paragraph = {
    * whose size is the maximum of the two margins.
    */
   margin?: Length | BoxLengths;
+  /**
+   * Align texts in paragraphs.
+   * Support `left`, `right` and `center`. By default texts are aligned to the `left`;
+   */
+  textAlign?: Alignment;
 } & TextAttrs;
 
 export type Shape = Rect | Line | Polyline;
@@ -212,3 +217,5 @@ export type NamedColor = keyof typeof namedColors;
  * A color specified in the hexadecimal format `#xxxxxx` that is usual in HTML.
  */
 export type HTMLColor = `#${string}`;
+
+export type Alignment = 'left' | 'right' | 'center';

--- a/test/layout.test.ts
+++ b/test/layout.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from '@jest/globals';
 
+import { Alignment } from '../src/content.js';
 import { layoutPage } from '../src/layout.js';
 import { fakeFont } from './test-utils.js';
 
@@ -96,6 +97,54 @@ describe('layout', () => {
         objectContaining({ type: 'text', x: 0, y: 0, text: 'foo ' }),
         objectContaining({ type: 'text', x: 40, y: 0, text: 'bar' }),
         objectContaining({ type: 'link', x: 0, y: 0, width: 70, height: 10, url: 'test-link' }),
+      ]);
+    });
+
+    it('align texts in paragraphs to right', () => {
+      const text = [{ text: 'foo', attrs: { fontSize: 10 } }];
+      const paragraphs = [
+        {
+          text,
+          textAlign: 'right' as Alignment,
+          margin: { left: 10, right: 20, top: 0, bottom: 0 },
+          padding: { left: 15, right: 25, top: 0, bottom: 0 },
+        },
+      ];
+
+      const frame = layoutPage(paragraphs, box, fonts);
+
+      expect(frame.children).toEqual([
+        objectContaining({ type: 'paragraph', x: 10, y: 0, width: 400 - 10 - 20, height: 12 }),
+      ]);
+      expect(frame.children[0].children).toEqual([
+        objectContaining({ type: 'row', x: 400 - 10 - 20 - 30 - 25, y: 0, width: 30, height: 12 }),
+      ]);
+    });
+
+    it('align texts in paragraphs to center', () => {
+      const text = [{ text: 'foo', attrs: { fontSize: 10 } }];
+      const paragraphs = [
+        {
+          text,
+          textAlign: 'center' as Alignment,
+          margin: { left: 10, right: 20, top: 0, bottom: 0 },
+          padding: { left: 15, right: 25, top: 0, bottom: 0 },
+        },
+      ];
+
+      const frame = layoutPage(paragraphs, box, fonts);
+
+      expect(frame.children).toEqual([
+        objectContaining({ type: 'paragraph', x: 10, y: 0, width: 400 - 10 - 20, height: 12 }),
+      ]);
+      expect(frame.children[0].children).toEqual([
+        objectContaining({
+          type: 'row',
+          x: (400 - 10 - 20 - 30 - 25 + 15) / 2,
+          y: 0,
+          width: 30,
+          height: 12,
+        }),
       ]);
     });
 


### PR DESCRIPTION
Previously all texts are aligned to the left by default. This change
adds support for the attribute textAlign on paragraphs. As in the
[CSS text-align], while setting textAlign to center, the texts
including the paddings are aligned to the center. While setting
textAlign to right, the texts including paddings are aligned to the
right. While `textAlign` is not set, align texts to the left.

[CSS text-align]: https://developer.mozilla.org/en-US/docs/Web/CSS/text-align