### PR TITLE
✨ Support multi-page documents

### DIFF
--- a/examples/sample.js
+++ b/examples/sample.js
@@ -94,5 +94,19 @@ export default {
       width: '3in',
       height: '3in',
     },
+    ...range(10).map((n) => ({
+      text:
+        `(${n + 1})` +
+        ' Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor' +
+        ' incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud' +
+        ' exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure' +
+        ' dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.' +
+        ' Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt' +
+        ' mollit anim id est laborum.',
+    })),
   ],
 };
+
+function range(n) {
+  return [...Array(n).keys()];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,20 +1,27 @@
-import { subtractEdges } from './box.js';
+import { parseEdges, parseLength, subtractEdges } from './box.js';
 import { DocumentDefinition } from './content.js';
 import { createDocument } from './document.js';
 import { embedFonts, parseFonts } from './fonts.js';
-import { layoutPage } from './layout.js';
+import { layoutPages } from './layout.js';
 import { createPage, renderPage } from './page.js';
 import { parseContent } from './text.js';
+import { optional, pick } from './types.js';
 
 export * from './content.js';
+
+const pageSize = { width: parseLength('210mm'), height: parseLength('297mm') }; // A4, portrait
+const defaultPageMargin = parseEdges('2cm');
 
 export async function makePdf(def: DocumentDefinition) {
   const doc = await createDocument(def);
   const fonts = await embedFonts(parseFonts(def.fonts), doc);
-  const page = createPage(doc, def);
-  const box = subtractEdges({ x: 0, y: 0, ...page.size }, page.margin);
-  const frame = layoutPage(parseContent(def), box, fonts);
-  renderPage(frame, page);
+  const pageMargin = pick(def, 'margin', optional(parseEdges)) ?? defaultPageMargin;
+  const box = subtractEdges({ x: 0, y: 0, ...pageSize }, pageMargin);
+  const frames = layoutPages(parseContent(def), box, fonts);
+  frames.forEach((frame) => {
+    const page = createPage(doc, pageSize, pageMargin, def);
+    renderPage(frame, page);
+  });
   const pdf = await doc.save();
   return pdf;
 }

--- a/src/page.ts
+++ b/src/page.ts
@@ -8,14 +8,12 @@ import {
   PDFRef,
 } from 'pdf-lib';
 
-import { BoxEdges, parseEdges, Pos, Size } from './box.js';
+import { BoxEdges, Pos, Size } from './box.js';
 import { LineObject, PolylineObject, RectObject } from './graphics.js';
 import { renderGuide } from './guides.js';
 import { Frame, LinkObject, TextObject } from './layout.js';
 import { addPageAnnotations, createLinkAnnotation } from './pdf-annotations.js';
 import { asObject, Obj, optional, pick, pickDefined } from './types.js';
-
-const defaultPageMargin = '2cm';
 
 export type Page = {
   pdfPage: PDFPage;
@@ -25,12 +23,12 @@ export type Page = {
   guides?: boolean;
 };
 
-export function createPage(doc: PDFDocument, def: Obj): Page {
-  const pdfPage = doc.addPage();
+export function createPage(doc: PDFDocument, size: Size, margin: BoxEdges, def: Obj): Page {
+  const pdfPage = doc.addPage([size.width, size.height]);
   return pickDefined({
     pdfPage,
-    size: pdfPage.getSize(),
-    margin: pick(def, 'margin', optional(parseEdges)) ?? parseEdges(defaultPageMargin),
+    size,
+    margin,
     guides: pick(def, 'dev', optional(asObject))?.guides,
   }) as Page;
 }

--- a/test/page.test.ts
+++ b/test/page.test.ts
@@ -6,36 +6,22 @@ import { Frame } from '../src/layout.js';
 import { createPage, renderFrame } from '../src/page.js';
 import { fakePdfFont } from './test-utils.js';
 
-const { anything, objectContaining } = expect;
+const { objectContaining } = expect;
 
 describe('page', () => {
   describe('createPage', () => {
-    let size, pdfPage, doc;
+    let size, margin, pdfPage, doc;
 
     beforeEach(() => {
       size = { width: 300, height: 400 };
-      pdfPage = { getSize: () => size };
+      margin = parseEdges(5);
       doc = { addPage: jest.fn().mockReturnValue(pdfPage) } as any;
     });
 
     it('creates page and returns wrapper', () => {
-      const page = createPage(doc, {} as any);
+      const page = createPage(doc, size, margin, {} as any);
 
-      expect(page).toEqual({ pdfPage, size, margin: anything() });
-    });
-
-    it('includes a default margin of 2cm', () => {
-      const page = createPage(doc, {} as any);
-
-      expect(page).toEqual(objectContaining({ margin: parseEdges('2cm') }));
-    });
-
-    it('includes margin from document definition', () => {
-      const margin = { left: '1cm', right: '2cm', top: '3cm', bottom: '4cm' };
-
-      const page = createPage(doc, { margin } as any);
-
-      expect(page).toEqual(objectContaining({ margin: parseEdges(margin) }));
+      expect(page).toEqual({ pdfPage, size, margin });
     });
   });
 

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -23,3 +23,7 @@ export function fakePdfFont(name: string): PDFFont {
     heightAtSize: (fontSize) => fontSize,
   } as any;
 }
+
+export function range(n) {
+  return [...Array(n).keys()];
+}


### PR DESCRIPTION
So far, pdf-maker could only create a single-page document.
To support longer documents, distribute content across multiple pages.

Let `layoutPage` stop when a paragraph does not fit on the page, and
return the page frame and the remaining paragraphs. Introduce a function
`layoutPages` that creates new pages for the remaining paragraphs.

This change only inserts page breaks between entire paragraphs, not
between rows. This is going to be improved later on.

Before, the page size used to be read from the page. Since the pages are
now created during rendering, this is not possible anymore. Set the page
size to A4 explicitly for now.