### PR TITLE
✨ Support columns

### DIFF
--- a/examples/sample.js
+++ b/examples/sample.js
@@ -75,24 +75,36 @@ export default {
       margin: { y: 5 },
     },
     {
-      graphics: [
+      columns: [
         {
-          type: 'polyline',
-          strokeWidth: 2,
-          fillColor: '#4488cc',
-          strokeColor: 'white',
-          points: [
-            { x: 100, y: 10 },
-            { x: 40, y: 198 },
-            { x: 190, y: 78 },
-            { x: 10, y: 78 },
-            { x: 160, y: 198 },
+          graphics: [
+            {
+              type: 'polyline',
+              strokeWidth: 2,
+              fillColor: '#4488cc',
+              strokeColor: 'white',
+              points: [
+                { x: 100, y: 10 },
+                { x: 40, y: 198 },
+                { x: 190, y: 78 },
+                { x: 10, y: 78 },
+                { x: 160, y: 198 },
+              ],
+              closePath: true,
+            },
           ],
-          closePath: true,
+          width: '3in',
+          height: '3in',
+          margin: 7,
+        },
+        {
+          text:
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor' +
+            ' incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud' +
+            ' exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+          margin: { left: 5 },
         },
       ],
-      width: '3in',
-      height: '3in',
     },
     ...range(10).map((n) => ({
       text:

--- a/src/content.ts
+++ b/src/content.ts
@@ -5,9 +5,9 @@ import { namedColors } from './colors.js';
  */
 export type DocumentDefinition = {
   /**
-   * The sequence of content elements to render.
+   * The sequence of blocks that contain the document's content.
    */
-  content: Paragraph[];
+  content: Block[];
   /**
    * The default style attributes to use in the document.
    */
@@ -82,6 +82,15 @@ export type FontDefinition = {
   italic?: boolean;
 };
 
+export type Block = Columns | Paragraph;
+
+export type Columns = {
+  /**
+   * Paragraphs to arrange horizontally.
+   */
+  columns: Paragraph[];
+} & BlockAttrs;
+
 export type Paragraph = {
   /**
    * Text to display in this paragraph.
@@ -98,16 +107,20 @@ export type Paragraph = {
    */
   padding?: Length | BoxLengths;
   /**
-   * Space to surround the paragraph.
-   * The `top` and `bottom` margins of adjacent paragraphs are collapsed into a single margin
-   * whose size is the maximum of the two margins.
-   */
-  margin?: Length | BoxLengths;
-  /**
    * Align texts in paragraphs.
    * Support `left`, `right` and `center`. By default texts are aligned to the `left`;
    */
   textAlign?: Alignment;
+} & TextAttrs &
+  BlockAttrs;
+
+export type BlockAttrs = {
+  /**
+   * Space to surround the block.
+   * The `top` and `bottom` margins of adjacent blocks are collapsed into a single margin
+   * whose size is the maximum of the two margins. Column margins don't collapse.
+   */
+  margin?: Length | BoxLengths;
   /**
    * A fixed width for the paragraph. If left out, the paragraph uses the available width.
    */
@@ -116,7 +129,7 @@ export type Paragraph = {
    * A fixed height for the paragraph. If left out, the height is defined by the included text.
    */
   height?: Length;
-} & TextAttrs;
+};
 
 export type Shape = Rect | Line | Polyline;
 

--- a/test/text.test.ts
+++ b/test/text.test.ts
@@ -56,7 +56,7 @@ describe('text', () => {
     it('checks paragraphs', () => {
       const input = { content: [{ text: 'foo' }, { text: 23 }] };
 
-      expect(() => parseContent(input)).toThrowError('Invalid value for "paragraph #2":');
+      expect(() => parseContent(input)).toThrowError('Invalid value for "block #2":');
     });
   });
 


### PR DESCRIPTION
To allow arranging paragraphs horizontally, this change introduces a
content type `Columns` as an alternative to `Paragraph`.
With this change, content is no longer a sequence of paragraphs, but a
sequence of blocks, that can be either of type `Columns` or `Paragraph`.
Other type of blocks may be added later to support different layouts.

The attributes `width`, `height`, and `margin` are extracted from
`Paragraph` and declared as block attributes. They should be supported
for all kinds of blocks, regardless of their type.

A `Columns` element is an object with a `columns` array. Columns are
again blocks. The columns layout respects the `width` attribute of
individual columns and distributes the remaining space evenly across the
columns that don't have a fixed width.

Since columns are not free floating, but arranged in a grid with
pre-calculated widths, margins of adjacent columns are not collapsed.
This would also not be very intuitive. A "column gap" attribute would
solve the same problem but in a clearer way. This attribute is not yet
implemented but may be added later.

The `parseBlock` and `parseColums` function are implemented next to
`parseParagraph` in `text.js`. This is an unfortunate place, but code
should be moved in a separate change.