### PR TITLE
♻️ Improve type checks

### DIFF
--- a/src/box.ts
+++ b/src/box.ts
@@ -1,4 +1,4 @@
-import { Obj } from './types.js';
+import { Obj, typeError } from './types.js';
 
 export type Pos = { x: number; y: number };
 export type Size = { width: number; height: number };
@@ -52,7 +52,7 @@ export function parseEdges(input?: unknown): BoxEdges | undefined {
       bottom: parseLength(obj.bottom ?? obj.y ?? 0),
     };
   }
-  throw new TypeError(`Invalid box lengths: '${input}'`);
+  throw typeError('number, length string, or object', input);
 }
 
 /**
@@ -76,7 +76,7 @@ export function parseLength(input?: unknown): number | undefined {
       }
     }
   }
-  throw new TypeError(`Invalid length: '${input}'`);
+  throw typeError('number or length string', input);
 }
 
 function convertToPt(value: number, fromUnit: string): number {

--- a/src/document.ts
+++ b/src/document.ts
@@ -45,10 +45,7 @@ export function parseInfo(input: unknown): Metadata {
 }
 
 function asStringArray(input: unknown): string[] {
-  asArray(input).forEach((el) => {
-    if (typeof el !== 'string') throw new TypeError(`Element is not a string: ${el}`);
-  });
-  return input as string[];
+  return asArray(input).map((el, idx) => check(el, `element ${idx + 1}`, asString));
 }
 
 function setMetadata(info: Metadata, doc: PDFDocument) {

--- a/src/text.ts
+++ b/src/text.ts
@@ -16,6 +16,7 @@ import {
   Obj,
   optional,
   pickDefined,
+  typeError,
 } from './types.js';
 
 const defaultFontSize = 18;
@@ -144,16 +145,12 @@ export function parseText(text: unknown, attrs: TextAttrs): TextSpan[] {
   if (typeof text === 'object' && 'text' in text) {
     return parseText((text as Obj).text, { ...attrs, ...parseTextAttrs(text as Obj) });
   }
-  throw new TypeError(
-    `Expected string, object with text attribute, or array of text, got: ${text}`
-  );
+  throw typeError('string, object with text attribute, or array of text', text);
 }
 
 function asTextAlign(input: unknown): Alignment {
-  if (input !== 'left' && input !== 'right' && input !== 'center') {
-    throw new TypeError(`Expected 'left', 'right', or 'center', got: ${input}`);
-  }
-  return input;
+  if (input === 'left' || input === 'right' || input === 'center') return input;
+  throw typeError("'left', 'right', or 'center'", input);
 }
 
 export function parseTextAttrs(input: Obj): TextAttrs {

--- a/test/box.test.ts
+++ b/test/box.test.ts
@@ -81,14 +81,20 @@ describe('box', () => {
     });
 
     it('throws on invalid lengths', () => {
-      expect(() => parseEdges('')).toThrowError("Invalid length: ''");
-      expect(() => parseEdges(Infinity)).toThrowError("Invalid length: 'Infinity'");
+      expect(() => parseEdges('')).toThrowError("Expected number or length string, got: ''");
+      expect(() => parseEdges(Infinity)).toThrowError(
+        'Expected number or length string, got: Infinity'
+      );
     });
 
     it('throws on invalid types', () => {
-      expect(() => parseEdges('')).toThrowError("Invalid length: ''");
-      expect(() => parseEdges(true)).toThrowError("Invalid box lengths: 'true'");
-      expect(() => parseEdges(() => 23)).toThrowError("Invalid box lengths: '() => 23'");
+      expect(() => parseEdges('')).toThrowError("Expected number or length string, got: ''");
+      expect(() => parseEdges(true)).toThrowError(
+        'Expected number, length string, or object, got: true'
+      );
+      expect(() => parseEdges(() => 23)).toThrowError(
+        'Expected number, length string, or object, got: anonymous function'
+      );
     });
   });
 
@@ -129,19 +135,23 @@ describe('box', () => {
     });
 
     it('throws on invalid strings', () => {
-      expect(() => parseLength('')).toThrowError("Invalid length: ''");
-      expect(() => parseLength('1')).toThrowError("Invalid length: '1'");
-      expect(() => parseLength('1xy')).toThrowError("Invalid length: '1xy'");
+      expect(() => parseLength('')).toThrowError("Expected number or length string, got: ''");
+      expect(() => parseLength('1')).toThrowError("Expected number or length string, got: '1'");
+      expect(() => parseLength('1xy')).toThrowError("Expected number or length string, got: '1xy'");
     });
 
     it('throws on invalid numbers', () => {
-      expect(() => parseLength(Infinity)).toThrowError("Invalid length: 'Infinity'");
-      expect(() => parseLength(NaN)).toThrowError("Invalid length: 'NaN'");
+      expect(() => parseLength(Infinity)).toThrowError(
+        'Expected number or length string, got: Infinity'
+      );
+      expect(() => parseLength(NaN)).toThrowError('Expected number or length string, got: NaN');
     });
 
     it('throws on invalid types', () => {
-      expect(() => parseLength(true)).toThrowError("Invalid length: 'true'");
-      expect(() => parseLength(() => 23)).toThrowError("Invalid length: '() => 23'");
+      expect(() => parseLength(true)).toThrowError('Expected number or length string, got: true');
+      expect(() => parseLength(() => 23)).toThrowError(
+        'Expected number or length string, got: anonymous function'
+      );
     });
   });
 });

--- a/test/document.test.ts
+++ b/test/document.test.ts
@@ -39,7 +39,7 @@ describe('document', () => {
         'Invalid value for "keywords": Expected array'
       );
       expect(() => parseInfo({ keywords: [23] })).toThrowError(
-        'Invalid value for "keywords": Element is not a string'
+        'Invalid value for "keywords": Invalid value for "element 1": Expected string, got: 23'
       );
     });
 

--- a/test/graphics.test.ts
+++ b/test/graphics.test.ts
@@ -12,14 +12,16 @@ import {
 describe('graphics', () => {
   describe('parseGraphicsObject', () => {
     it('throws for invalid types', () => {
-      expect(() => parseGraphicsObject(23)).toThrowError('Invalid graphics object: 23');
-      expect(() => parseGraphicsObject('foo')).toThrowError('Invalid graphics object: foo');
+      expect(() => parseGraphicsObject(23)).toThrowError('Expected object, got: 23');
+      expect(() => parseGraphicsObject('foo')).toThrowError("Expected object, got: 'foo'");
     });
 
     it('throws for unsupported type attribute', () => {
       const fn = () => parseGraphicsObject({ type: 'foo' });
 
-      expect(fn).toThrowError('Unsupported graphics object type: "foo"');
+      expect(fn).toThrowError(
+        "Invalid value for \"type\": Expected 'rect', 'line', or 'polyline', got: 'foo'"
+      );
     });
 
     it('parses rect object', () => {
@@ -44,9 +46,7 @@ describe('graphics', () => {
 
         const fn = () => parseGraphicsObject(rect);
 
-        expect(fn).toThrowError(
-          `Invalid graphics object of type "rect": Missing value for "${name}"`
-        );
+        expect(fn).toThrowError(`Missing value for "${name}"`);
       });
     });
 
@@ -70,9 +70,7 @@ describe('graphics', () => {
 
         const fn = () => parseGraphicsObject(line);
 
-        expect(fn).toThrowError(
-          `Invalid graphics object of type "line": Missing value for "${name}"`
-        );
+        expect(fn).toThrowError(`Missing value for "${name}"`);
       });
     });
 
@@ -94,9 +92,7 @@ describe('graphics', () => {
     it(`throws for missing polyline attribute points`, () => {
       const fn = () => parseGraphicsObject({ type: 'polyline' });
 
-      expect(fn).toThrowError(
-        `Invalid graphics object of type "polyline": Missing value for "points"`
-      );
+      expect(fn).toThrowError(`Missing value for "points"`);
     });
 
     ['strokeColor', 'fillColor'].forEach((name) => {
@@ -105,9 +101,7 @@ describe('graphics', () => {
 
         const fn = () => parseGraphicsObject(rect);
 
-        expect(fn).toThrowError(
-          `Invalid graphics object of type "rect": Invalid value for "${name}": Unsupported color name: 'foo'`
-        );
+        expect(fn).toThrowError(`Invalid value for "${name}": Unsupported color name: 'foo'`);
       });
     });
 
@@ -117,7 +111,7 @@ describe('graphics', () => {
       const fn = () => parseGraphicsObject(rect);
 
       expect(fn).toThrowError(
-        'Invalid graphics object of type "rect": Invalid value for "strokeWidth": Expected non-negative number, got: -1'
+        'Invalid value for "strokeWidth": Expected non-negative number, got: -1'
       );
     });
   });

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -3,12 +3,16 @@ import { describe, expect, it } from '@jest/globals';
 import {
   asArray,
   asBoolean,
+  asDate,
+  asNonNegNumber,
   asNumber,
   asObject,
+  asString,
   check,
   getFrom,
   optional,
   pickDefined,
+  printValue,
   required,
 } from '../src/types.js';
 
@@ -111,6 +115,10 @@ describe('types', () => {
       expect(optional(fn)(23)).toEqual('23');
     });
 
+    it('returns function that returns value if no function given', () => {
+      expect(optional()(23)).toEqual(23);
+    });
+
     it('returns function that returns undefined if input is undefined', () => {
       expect(optional(fn)(undefined)).toBeUndefined();
     });
@@ -152,9 +160,21 @@ describe('types', () => {
       expect(asBoolean(false)).toBe(false);
     });
 
-    it('throws for non-boolean values', () => {
+    it('throws for other types', () => {
       expect(() => asBoolean(23)).toThrowError('Expected boolean, got: 23');
       expect(() => asBoolean(null)).toThrowError('Expected boolean, got: null');
+    });
+  });
+
+  describe('asString', () => {
+    it('returns strings', () => {
+      expect(asString('foo')).toBe('foo');
+      expect(asString('')).toBe('');
+    });
+
+    it('throws for other types', () => {
+      expect(() => asString(23)).toThrowError('Expected string, got: 23');
+      expect(() => asString(null)).toThrowError('Expected string, got: null');
     });
   });
 
@@ -168,6 +188,41 @@ describe('types', () => {
       expect(() => asNumber(NaN)).toThrowError('Expected number, got: NaN');
       expect(() => asNumber(Infinity)).toThrowError('Expected number, got: Infinity');
     });
+
+    it('throws for other types', () => {
+      expect(() => asNumber('23')).toThrowError("Expected number, got: '23'");
+      expect(() => asNumber(null)).toThrowError('Expected number, got: null');
+    });
+  });
+
+  describe('asNonNegNumber', () => {
+    it('returns zero and positive numbers', () => {
+      expect(asNonNegNumber(0)).toBe(0);
+      expect(asNonNegNumber(23)).toBe(23);
+    });
+
+    it('throws for negative numbers', () => {
+      expect(() => asNonNegNumber(-1)).toThrowError('Expected non-negative number, got: -1');
+    });
+  });
+
+  describe('asDate', () => {
+    it('returns date objects', () => {
+      const date = new Date('2000-04-01T12:13:14.000Z');
+
+      expect(asDate(date)).toBe(date);
+    });
+
+    it('throws for date strings', () => {
+      expect(() => asDate('2000-04-01T12:13:14.000Z')).toThrowError(
+        "Expected Date, got: '2000-04-01T12:13:14.000Z'"
+      );
+    });
+
+    it('throws for other types', () => {
+      expect(() => asDate(23)).toThrowError('Expected Date, got: 23');
+      expect(() => asDate(null)).toThrowError('Expected Date, got: null');
+    });
   });
 
   describe('asArray', () => {
@@ -177,9 +232,9 @@ describe('types', () => {
     });
 
     it('throws for objects', () => {
-      expect(() => asArray({})).toThrowError('Expected array, got: [object Object]');
-      expect(() => asArray(new ArrayBuffer(3))).toThrowError(
-        'Expected array, got: [object ArrayBuffer]'
+      expect(() => asArray({})).toThrowError('Expected array, got: {}');
+      expect(() => asArray(Uint8Array.of(1, 2, 3).buffer)).toThrowError(
+        'Expected array, got: ArrayBuffer [1, 2, 3]'
       );
     });
   });
@@ -191,7 +246,99 @@ describe('types', () => {
     });
 
     it('throws for arrays', () => {
-      expect(() => asObject([])).toThrowError('Expected object, got: ');
+      expect(() => asObject([])).toThrowError('Expected object, got: []');
+    });
+  });
+
+  describe('printValue', () => {
+    it('prints strings', () => {
+      expect(printValue('')).toEqual("''");
+      expect(printValue('foo')).toEqual("'foo'");
+    });
+
+    it('prints numbers', () => {
+      expect(printValue(0)).toEqual('0');
+      expect(printValue(23)).toEqual('23');
+    });
+
+    it('prints boolean values', () => {
+      expect(printValue(true)).toEqual('true');
+      expect(printValue(false)).toEqual('false');
+    });
+
+    it('prints Date objects', () => {
+      expect(printValue(new Date('2001-02-03T04:05:06.789Z'))).toEqual(
+        'Date 2001-02-03T04:05:06.789Z'
+      );
+    });
+
+    it('prints functions', () => {
+      expect(printValue((x) => x)).toEqual('anonymous function');
+      expect(printValue(async (x) => x)).toEqual('anonymous function');
+      expect(printValue(printValue)).toEqual('function printValue');
+    });
+
+    it('prints ArrayBuffers', () => {
+      expect(printValue(Uint8Array.of(1, 2, 3).buffer)).toEqual('ArrayBuffer [1, 2, 3]');
+    });
+
+    it('prints typed arrays', () => {
+      expect(printValue(Uint8Array.of(1, 2, 3))).toEqual('Uint8Array [1, 2, 3]');
+      expect(printValue(Int8Array.of(-1, -2, -3))).toEqual('Int8Array [255, 254, 253]');
+    });
+
+    it('prints arrays', () => {
+      expect(printValue([])).toEqual('[]');
+      expect(printValue([1, 2, 3])).toEqual('[1, 2, 3]');
+      expect(printValue(['a', 'b', 'c'])).toEqual("['a', 'b', 'c']");
+    });
+
+    it('prints nested arrays', () => {
+      expect(printValue([[]])).toEqual('[[]]');
+      expect(printValue([1, 2, [3, 4]])).toEqual('[1, 2, [3, 4]]');
+    });
+
+    it('prints only first 8 elements of arrays', () => {
+      const arr = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+      expect(printValue(arr)).toEqual('[0, 1, 2, 3, 4, 5, 6, 7, …]');
+    });
+
+    it('handles circular references in arrays', () => {
+      const arr = [0, {}];
+      arr.push(arr);
+
+      expect(printValue(arr)).toEqual('[0, {}, recursive ref]');
+    });
+
+    it('prints objects', () => {
+      expect(printValue({})).toEqual('{}');
+      expect(printValue({ a: 1, b: 2 })).toEqual('{a: 1, b: 2}');
+      expect(printValue({ a: 'a', b: 'b' })).toEqual("{a: 'a', b: 'b'}");
+    });
+
+    it('prints nested objects', () => {
+      expect(printValue({ a: 1, b: { c: 2 } })).toEqual('{a: 1, b: {c: 2}}');
+    });
+
+    it('prints only first 8 entries of objects', () => {
+      const obj = { a: 0, b: 1, c: 2, d: 3, e: 4, f: 5, g: 6, h: 7, i: 8, j: 9 };
+
+      expect(printValue(obj)).toEqual('{a: 0, b: 1, c: 2, d: 3, e: 4, f: 5, g: 6, h: 7, …}');
+    });
+
+    it('handles circular references in objects', () => {
+      const obj = { a: 0, b: {} };
+      obj.b = obj;
+
+      expect(printValue(obj)).toEqual('{a: 0, b: recursive ref}');
+    });
+
+    it('handles deep circular references in objects', () => {
+      const obj = { a: 0, b: [1, 2, {}] };
+      obj.b.push({ obj });
+
+      expect(printValue(obj)).toEqual('{a: 0, b: [1, 2, {}, {obj: recursive ref}]}');
     });
   });
 });


### PR DESCRIPTION
When type checking input data, a util function is used to create a
`TypeError` with a message following the common pattern
"Expected {this}, got: {that}".
Rename this function to `typeError()`, export it, and replace manually
created type errors with this function where possible to align all error
messages to the same pattern.

Including the actual value in the error message directly conceals
certain values. For example, an empty array would be represented by the
empty string, objects as `[object Object]`. Numbers cannot be
distinguished from numeric strings. This can lead to confusing error
messages such as "Expected number, got 23".

To avoid this confusion, implement custom print functions for common
types such as strings, arrays, and objects.

Support using `optional()` without arguments to match the behavior of
`required()` without arguments (return the input value unmodified).
Remove a useless optional chaining operator in the implementation of
`getFrom()`.