### PR TITLE
✨ Support internal links

### DIFF
--- a/examples/sample.js
+++ b/examples/sample.js
@@ -135,6 +135,20 @@ export default {
       image: 'liberty',
       height: 200,
     },
+    {
+      rows: [
+        {
+          text: 'Contents',
+          fontSize: 18,
+          margin: { bottom: 5 },
+        },
+        ...range(10).map((n) => ({
+          text: `Paragraph ${n + 1}`,
+          link: `#par:${n + 1}`,
+        })),
+      ],
+      margin: { bottom: 10 },
+    },
     ...range(10).map((n) => ({
       text:
         `(${n + 1})` +
@@ -144,6 +158,7 @@ export default {
         ' dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.' +
         ' Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt' +
         ' mollit anim id est laborum.',
+      id: `par:${n + 1}`,
     })),
   ],
 };

--- a/src/content.ts
+++ b/src/content.ts
@@ -177,6 +177,12 @@ export type BlockAttrs = {
    * A fixed height for the paragraph. If left out, the height is defined by the included text.
    */
   height?: Length;
+  /**
+   * An optional *unique* id for the element. When an `id` is specified, an anchor with this id
+   * will be included in the PDF document that can be used to refer to this element using the text
+   * attribute `link`.
+   */
+  id?: string;
 };
 
 export type PageInfo = {
@@ -258,8 +264,10 @@ export type TextAttrs = {
    */
   color?: Color;
   /**
-   * A URL to point to. When this property is given, the corresponding text will be rendered
-   * as a link to this URL.
+   * A link target. When this attribute is present, the corresponding text will be rendered as a
+   * link to the given target. The target can either be a URL or a reference to an anchor in the
+   * document. An internal reference starts with a hash sign (`#`), followed by the `id` of an
+   * element in the document.
    */
   link?: string;
 };

--- a/src/page.ts
+++ b/src/page.ts
@@ -11,8 +11,8 @@ import {
 import { Pos, Size } from './box.js';
 import { ImageObject, LineObject, PolylineObject, RectObject } from './graphics.js';
 import { renderGuide } from './guides.js';
-import { Frame, LinkObject, TextObject } from './layout.js';
-import { createLinkAnnotation } from './pdf-annotations.js';
+import { DestObject, Frame, LinkObject, TextObject } from './layout.js';
+import { createLinkAnnotation, createNamedDest } from './pdf-annotations.js';
 
 export type Page = {
   size: Size;
@@ -38,6 +38,9 @@ export function renderFrame(frame: Frame, page: Page, base: Pos = null) {
   frame.objects?.forEach((object) => {
     if (object.type === 'text') {
       renderText(object, page, bottomLeft);
+    }
+    if (object.type === 'dest') {
+      renderDest(object, page, topLeft);
     }
     if (object.type === 'link') {
       renderLink(object, page, bottomLeft);
@@ -65,6 +68,11 @@ function renderText(el: TextObject, page: Page, base: Pos) {
   const options: PDFPageDrawTextOptions = { x, y, size: el.fontSize, font: el.font };
   if (el.color) options.color = el.color;
   page.pdfPage.drawText(el.text, options);
+}
+
+function renderDest(el: DestObject, page: Page, base: Pos) {
+  const { x, y } = tr({ x: el.x + base.x, y: el.y + base.y }, page);
+  createNamedDest(page.pdfPage, el.name, { x, y });
 }
 
 function renderLink(el: LinkObject, page: Page, base: Pos) {

--- a/src/pdf-annotations.ts
+++ b/src/pdf-annotations.ts
@@ -1,22 +1,38 @@
-import { PDFArray, PDFName, PDFPage, PDFString } from 'pdf-lib';
+import { PDFArray, PDFDict, PDFName, PDFObject, PDFPage, PDFString } from 'pdf-lib';
 
-import { Box } from './box.js';
+import { Box, Pos } from './box.js';
 
 export function createLinkAnnotation(page: PDFPage, box: Box, uri: string) {
-  if (!page.node.has(PDFName.of('Annots'))) {
-    page.node.set(PDFName.of('Annots'), page.doc.context.obj([]));
-  }
-  const annots = page.node.get(PDFName.of('Annots')) as PDFArray;
+  const annots = getOrCreate(page.node, 'Annots', () => []) as PDFArray;
   const annot = page.doc.context.obj({
     Type: 'Annot',
     Subtype: 'Link',
     Rect: [box.x, box.y, box.x + box.width, box.y + box.height],
-    A: {
-      Type: 'Action',
-      S: 'URI',
-      URI: PDFString.of(uri),
-    },
+    ...(uri.startsWith('#')
+      ? { A: { Type: 'Action', S: 'GoTo', D: PDFString.of(uri.slice(1)) } }
+      : { A: { Type: 'Action', S: 'URI', URI: PDFString.of(uri) } }),
+    C: page.doc.context.obj([]),
     F: 0, // required for PDF/A
   });
   annots.push(page.doc.context.register(annot));
+}
+
+export function createNamedDest(page: PDFPage, name: string, pos: Pos) {
+  const names = getOrCreate(page.doc.catalog, 'Names', () => ({})) as PDFDict;
+  const dests = getOrCreate(names, 'Dests', () => ({})) as PDFDict;
+  const destNames = getOrCreate(dests, 'Names', () => []) as PDFArray;
+  for (let i = 0; i < destNames.size(); i += 2) {
+    if ((destNames.get(i) as PDFString).asString() === name) {
+      throw new Error(`Duplicate id ${name}`);
+    }
+  }
+  destNames.push(PDFString.of(name));
+  destNames.push(page.doc.context.obj([page.ref, 'XYZ', pos.x, pos.y, null]));
+}
+
+function getOrCreate(dict: PDFDict, name: string, creatorFn: () => any): PDFObject {
+  if (!dict.has(PDFName.of(name))) {
+    dict.set(PDFName.of(name), dict.context.obj(creatorFn()));
+  }
+  return dict.get(PDFName.of(name));
 }

--- a/src/text.ts
+++ b/src/text.ts
@@ -55,11 +55,13 @@ export type Block = Columns | Rows | Paragraph;
 
 export type Columns = {
   columns: Block[];
-} & BlockAttrs;
+} & BlockAttrs &
+  TextAttrs;
 
 export type Rows = {
   rows: Block[];
-} & BlockAttrs;
+} & BlockAttrs &
+  TextAttrs;
 
 export type Paragraph = {
   text?: TextSpan[];
@@ -74,7 +76,8 @@ export type BlockAttrs = {
   margin?: BoxEdges;
   width?: number;
   height?: number;
-} & TextAttrs;
+  id?: string;
+};
 
 export function parseContent(content: unknown[], defaultStyle: TextAttrs): Paragraph[] {
   return content.map((block, idx) =>
@@ -134,6 +137,7 @@ function parseBlockAttrs(input: Obj): BlockAttrs {
     margin: getFrom(input, 'margin', optional(parseEdges)),
     width: getFrom(input, 'width', optional(parseLength)),
     height: getFrom(input, 'height', optional(parseLength)),
+    id: getFrom(input, 'id', optional(asString)),
   });
 }
 


### PR DESCRIPTION
Support anchors on block elements by adding a unique `id` attribute.
Anchors are included as [named destinations] in the `Dests` element of
the document's [name dictionary].

Allow links to those named destinations by setting the text attribute
`link` to a hash sign (`#`) followed by the id of the referenced
element.
This approach seems simple and intuitive, it matches the way that links
to internal anchors are defined in HTML documents.
When a link starts with a hash sign, assume it's an internal link and
render it using a [goto action] to this named destination.

[named destinations]: See Adobe PDF 1.7, section 8.2.1, Destinations
https://archive.org/details/pdf1.7/page/n579/mode/2up

[name dictionary]: See Adobe PDF 1.7, section 3.6.3, Name Dictionary
https://archive.org/details/pdf1.7/page/n149/mode/2up

[goto action]: See Adobe PDF 1.7, section 8.5.3, Action Types
https://archive.org/details/pdf1.7/page/n651/mode/2up