### PR TITLE
♻️ Improve error messages for nested attributes

### DIFF
--- a/src/document.ts
+++ b/src/document.ts
@@ -53,7 +53,7 @@ function parseCustomAttrs(custom: Obj): Record<string, string> {
 }
 
 function asStringArray(input: unknown): string[] {
-  return asArray(input).map((el, idx) => check(el, `element ${idx + 1}`, asString));
+  return asArray(input).map((el, idx) => check(el, `[${idx}]`, asString));
 }
 
 function setMetadata(info: Metadata, doc: PDFDocument) {

--- a/src/fonts.ts
+++ b/src/fonts.ts
@@ -36,9 +36,9 @@ export type FontSelector = {
 export function parseFonts(input: unknown): FontDef[] {
   const obj = check(input, 'fonts', optional(asObject)) ?? {};
   return Object.entries(obj).flatMap(([name, fontDef]) => {
-    const array = check(fontDef, `fonts > ${name}`, required(asArray));
+    const array = check(fontDef, `fonts['${name}']`, required(asArray));
     return array.map((fontDef, idx) => {
-      const font = check(fontDef, `fonts > ${name} > #${idx + 1}`, required(parseFont));
+      const font = check(fontDef, `fonts['${name}'][${idx}]`, required(parseFont));
       return { name, ...font } as FontDef;
     });
   });

--- a/src/graphics.ts
+++ b/src/graphics.ts
@@ -59,9 +59,7 @@ export type ImageObject = {
 };
 
 export function parseGraphics(input: unknown): GraphicsObject[] {
-  return check(input, 'graphics', optional(asArray))?.map((el, idx) =>
-    check(el, `graphics object ${idx + 1} (type "${el['type']}")`, parseGraphicsObject)
-  );
+  return asArray(input)?.map((el, idx) => check(el, `[${idx}]`, parseGraphicsObject));
 }
 
 /**
@@ -165,7 +163,7 @@ function shiftPolyline(polyline: PolylineObject, pos: Pos): PolylineObject {
 }
 
 function asPoints(input: unknown): { x: number; y: number }[] {
-  return asArray(input).map((point, idx) => check(point, `point ${idx + 1}`, asPoint));
+  return asArray(input).map((point, idx) => check(point, `[${idx}]`, asPoint));
 }
 
 function asPoint(input: unknown): { x: number; y: number } {

--- a/src/images.ts
+++ b/src/images.ts
@@ -16,7 +16,7 @@ export type Image = {
 export function parseImages(input: unknown): ImageDef[] {
   const obj = check(input, 'images', optional(asObject)) ?? {};
   return Object.entries(obj).map(([name, imageDef]) => {
-    const data = check(imageDef, `images > ${name}`, required(parseImage));
+    const data = check(imageDef, `images['${name}']`, required(parseImage));
     return { name, data };
   });
 }

--- a/src/text.ts
+++ b/src/text.ts
@@ -82,7 +82,7 @@ type InheritableAttrs = TextAttrs & {
 
 export function parseContent(content: unknown[], defaultStyle: InheritableAttrs): Paragraph[] {
   return content.map((block, idx) =>
-    check(block, `content block #${idx + 1}`, () => parseBlock(asObject(block), defaultStyle))
+    check(block, `content[${idx}]`, () => parseBlock(asObject(block), defaultStyle))
   );
 }
 
@@ -100,7 +100,7 @@ export function parseColumns(input: Obj, defaultAttrs?: InheritableAttrs): Colum
   const mergedAttrs = { ...defaultAttrs, ...parseInheritableAttrs(input) };
   const parseColumns = (columns) =>
     asArray(columns).map((col, idx) =>
-      check(col, `column #${idx + 1}`, () => parseBlock(col as Obj, mergedAttrs))
+      check(col, `[${idx}]`, () => parseBlock(col as Obj, mergedAttrs))
     );
   return pickDefined({
     columns: getFrom(input, 'columns', parseColumns),
@@ -112,7 +112,7 @@ export function parseRows(input: Obj, defaultAttrs?: InheritableAttrs): Columns 
   const mergedAttrs = { ...defaultAttrs, ...parseInheritableAttrs(input) };
   const parseRows = (rows) =>
     asArray(rows).map((col, idx) =>
-      check(col, `row #${idx + 1}`, () => parseBlock(col as Obj, mergedAttrs))
+      check(col, `[${idx}]`, () => parseBlock(col as Obj, mergedAttrs))
     );
   return pickDefined({
     rows: getFrom(input, 'rows', parseRows),

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,11 +24,15 @@ export function check<T = unknown>(value: unknown, name: string, fn?: (value: un
   try {
     return fn?.(value) ?? (value as T);
   } catch (error) {
-    const message =
-      error.message === 'Missing value'
-        ? `Missing value for "${name}"`
-        : `Invalid value for "${name}": ${error.message}`;
-    throw new TypeError(message);
+    if (error.message === 'Missing value') {
+      throw new TypeError(`Missing value for "${name}"`);
+    }
+    if (error.message?.startsWith('Invalid value for "')) {
+      const tail = error.message.replace(/^Invalid value for "/, '');
+      const glue = tail.startsWith('[') ? '' : '.';
+      throw new TypeError(`Invalid value for "${name}${glue}${tail}`);
+    }
+    throw new TypeError(`Invalid value for "${name}": ${error.message}`);
   }
 }
 

--- a/test/document.test.ts
+++ b/test/document.test.ts
@@ -56,7 +56,7 @@ describe('document', () => {
         'Invalid value for "keywords": Expected array'
       );
       expect(() => parseInfo({ keywords: [23] })).toThrowError(
-        'Invalid value for "keywords": Invalid value for "element 1": Expected string, got: 23'
+        'Invalid value for "keywords[0]": Expected string, got: 23'
       );
     });
 

--- a/test/fonts.test.ts
+++ b/test/fonts.test.ts
@@ -40,13 +40,13 @@ describe('fonts', () => {
     it('throws on invalid italic value', () => {
       const fn = () => parseFonts({ Test: [{ data: 'data', italic: 23 }] });
 
-      expect(fn).toThrowError('Invalid value for "fonts > Test > #1": Invalid value for "italic":');
+      expect(fn).toThrowError('Invalid value for "fonts[\'Test\'][0].italic":');
     });
 
     it('throws on invalid bold value', () => {
       const fn = () => parseFonts({ Test: [{ data: 'data', bold: 23 }] });
 
-      expect(fn).toThrowError('Invalid value for "fonts > Test > #1": Invalid value for "bold":');
+      expect(fn).toThrowError('Invalid value for "fonts[\'Test\'][0].bold":');
     });
 
     it('throws on missing data', () => {

--- a/test/graphics.test.ts
+++ b/test/graphics.test.ts
@@ -95,6 +95,12 @@ describe('graphics', () => {
       expect(fn).toThrowError(`Missing value for "points"`);
     });
 
+    it(`throws for invalid point in polyline`, () => {
+      const fn = () => parseGraphicsObject({ type: 'polyline', points: [{ x: 1, y: 'a' }] });
+
+      expect(fn).toThrowError(`Invalid value for "points[0].y": Expected number, got: 'a'`);
+    });
+
     ['strokeColor', 'fillColor'].forEach((name) => {
       it(`throws for invalid rect attribute ${name}`, () => {
         const rect = { type: 'rect', x: 1, y: 2, width: 10, height: 20, [name]: 'foo' };

--- a/test/images.test.ts
+++ b/test/images.test.ts
@@ -33,13 +33,13 @@ describe('images', () => {
     it('throws on invalid image definition', () => {
       const fn = () => parseImages({ foo: 23 });
 
-      expect(fn).toThrowError('Invalid value for "images > foo": Expected object, got: 23');
+      expect(fn).toThrowError('Invalid value for "images[\'foo\']": Expected object, got: 23');
     });
 
     it('throws on invalid image data', () => {
       const fn = () => parseImages({ foo: { data: 23 } });
 
-      expect(fn).toThrowError('Invalid value for "images > foo": Invalid value for "data":');
+      expect(fn).toThrowError('Invalid value for "images[\'foo\'].data":');
     });
   });
 

--- a/test/layout.test.ts
+++ b/test/layout.test.ts
@@ -20,7 +20,9 @@ describe('layout', () => {
     it('checks defaultStyle', () => {
       const def = { defaultStyle: { fontSize: -1 }, content: [] };
 
-      expect(() => layoutPages(def, resources)).toThrowError('Invalid value for "defaultStyle":');
+      expect(() => layoutPages(def, resources)).toThrowError(
+        'Invalid value for "defaultStyle.fontSize":'
+      );
     });
 
     it('checks margin', () => {

--- a/test/text.test.ts
+++ b/test/text.test.ts
@@ -46,7 +46,7 @@ describe('text', () => {
     it('checks content', () => {
       const content = [{ text: 'foo' }, { text: 23 }];
 
-      expect(() => parseContent(content, {})).toThrowError('Invalid value for "content block #2":');
+      expect(() => parseContent(content, {})).toThrowError('Invalid value for "content[1].text":');
     });
   });
 

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -72,6 +72,30 @@ describe('types', () => {
       expect(fn).toThrowError('Invalid value for "foo": bad value');
     });
 
+    it('merges nested error messages', () => {
+      const input = 23;
+      const bad = () => {
+        throw new TypeError('bad value');
+      };
+      const nestedCheck = () => check(input, 'bar', bad);
+
+      const fn = () => check(input, 'foo', nestedCheck);
+
+      expect(fn).toThrowError('Invalid value for "foo.bar": bad value');
+    });
+
+    it('handles bracket notation in nested error messages', () => {
+      const input = 23;
+      const bad = () => {
+        throw new TypeError('bad value');
+      };
+      const nestedCheck = () => check(input, '[0]', bad);
+
+      const fn = () => check(input, 'foo', nestedCheck);
+
+      expect(fn).toThrowError('Invalid value for "foo[0]": bad value');
+    });
+
     it('throws for missing value', () => {
       const fn = () => check(undefined, 'foo', required());
 


### PR DESCRIPTION
Type checks on nested attributes lead to nested error messages such as
`Invalid value for "foo": Invalid value for "bar": Expected …, got: …`.

This change improves those error messages by using a path-like pattern
to refer to nested attributes, e.g.:
`Invalid value for "foo / bar": Expected …, got: …`.

Array elements are already referred to using a human-readable index
number (i.e. starting at 1), for example `fonts / Test_Font / #1`.
Compared to the JSONPath equivalent `fonts.Test_Font[0]`, this appears
easier to read.