### PR TITLE
♻️ Use JSON Pointer syntax in nested type errors

### DIFF
--- a/src/document.ts
+++ b/src/document.ts
@@ -65,7 +65,7 @@ function parseCustomAttrs(custom: Obj): Record<string, string> {
 }
 
 function asStringArray(input: unknown): string[] {
-  return asArray(input).map((el, idx) => check(el, `[${idx}]`, asString));
+  return asArray(input).map((el, idx) => check(el, `${idx}`, asString));
 }
 
 function setMetadata(info: Metadata, doc: PDFDocument) {

--- a/src/fonts.ts
+++ b/src/fonts.ts
@@ -36,9 +36,9 @@ export type FontSelector = {
 export function parseFonts(input: unknown): FontDef[] {
   const obj = check(input, 'fonts', optional(asObject)) ?? {};
   return Object.entries(obj).flatMap(([name, fontDef]) => {
-    const array = check(fontDef, `fonts['${name}']`, required(asArray));
+    const array = check(fontDef, `fonts/${name}`, required(asArray));
     return array.map((fontDef, idx) => {
-      const font = check(fontDef, `fonts['${name}'][${idx}]`, required(parseFont));
+      const font = check(fontDef, `fonts/${name}/${idx}`, required(parseFont));
       return { name, ...font } as FontDef;
     });
   });

--- a/src/graphics.ts
+++ b/src/graphics.ts
@@ -59,7 +59,7 @@ export type ImageObject = {
 };
 
 export function parseGraphics(input: unknown): GraphicsObject[] {
-  return asArray(input)?.map((el, idx) => check(el, `[${idx}]`, parseGraphicsObject));
+  return asArray(input)?.map((el, idx) => check(el, `${idx}`, parseGraphicsObject));
 }
 
 /**
@@ -163,7 +163,7 @@ function shiftPolyline(polyline: PolylineObject, pos: Pos): PolylineObject {
 }
 
 function asPoints(input: unknown): { x: number; y: number }[] {
-  return asArray(input).map((point, idx) => check(point, `[${idx}]`, asPoint));
+  return asArray(input).map((point, idx) => check(point, `${idx}`, asPoint));
 }
 
 function asPoint(input: unknown): { x: number; y: number } {

--- a/src/images.ts
+++ b/src/images.ts
@@ -16,7 +16,7 @@ export type Image = {
 export function parseImages(input: unknown): ImageDef[] {
   const obj = check(input, 'images', optional(asObject)) ?? {};
   return Object.entries(obj).map(([name, imageDef]) => {
-    const data = check(imageDef, `images['${name}']`, required(parseImage));
+    const data = check(imageDef, `images/${name}`, required(parseImage));
     return { name, data };
   });
 }

--- a/src/text.ts
+++ b/src/text.ts
@@ -87,7 +87,7 @@ type InheritableAttrs = TextAttrs & {
 
 export function parseContent(content: unknown[], defaultStyle: InheritableAttrs): Paragraph[] {
   return content.map((block, idx) =>
-    check(block, `content[${idx}]`, () => parseBlock(asObject(block), defaultStyle))
+    check(block, `content/${idx}`, () => parseBlock(asObject(block), defaultStyle))
   );
 }
 
@@ -105,7 +105,7 @@ export function parseColumns(input: Obj, defaultAttrs?: InheritableAttrs): Colum
   const mergedAttrs = { ...defaultAttrs, ...parseInheritableAttrs(input) };
   const parseColumns = (columns) =>
     asArray(columns).map((col, idx) =>
-      check(col, `[${idx}]`, () => parseBlock(col as Obj, mergedAttrs))
+      check(col, `${idx}`, () => parseBlock(col as Obj, mergedAttrs))
     );
   return pickDefined({
     columns: getFrom(input, 'columns', parseColumns),
@@ -117,7 +117,7 @@ export function parseRows(input: Obj, defaultAttrs?: InheritableAttrs): Columns 
   const mergedAttrs = { ...defaultAttrs, ...parseInheritableAttrs(input) };
   const parseRows = (rows) =>
     asArray(rows).map((col, idx) =>
-      check(col, `[${idx}]`, () => parseBlock(col as Obj, mergedAttrs))
+      check(col, `${idx}`, () => parseBlock(col as Obj, mergedAttrs))
     );
   return pickDefined({
     rows: getFrom(input, 'rows', parseRows),

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,8 +29,7 @@ export function check<T = unknown>(value: unknown, name: string, fn?: (value: un
     }
     if (error.message?.startsWith('Invalid value for "')) {
       const tail = error.message.replace(/^Invalid value for "/, '');
-      const glue = tail.startsWith('[') ? '' : '.';
-      throw new TypeError(`Invalid value for "${name}${glue}${tail}`);
+      throw new TypeError(`Invalid value for "${name}/${tail}`);
     }
     throw new TypeError(`Invalid value for "${name}": ${error.message}`);
   }

--- a/test/document.test.ts
+++ b/test/document.test.ts
@@ -56,7 +56,7 @@ describe('document', () => {
         'Invalid value for "keywords": Expected array'
       );
       expect(() => parseInfo({ keywords: [23] })).toThrowError(
-        'Invalid value for "keywords[0]": Expected string, got: 23'
+        'Invalid value for "keywords/0": Expected string, got: 23'
       );
     });
 

--- a/test/fonts.test.ts
+++ b/test/fonts.test.ts
@@ -40,13 +40,13 @@ describe('fonts', () => {
     it('throws on invalid italic value', () => {
       const fn = () => parseFonts({ Test: [{ data: 'data', italic: 23 }] });
 
-      expect(fn).toThrowError('Invalid value for "fonts[\'Test\'][0].italic":');
+      expect(fn).toThrowError('Invalid value for "fonts/Test/0/italic":');
     });
 
     it('throws on invalid bold value', () => {
       const fn = () => parseFonts({ Test: [{ data: 'data', bold: 23 }] });
 
-      expect(fn).toThrowError('Invalid value for "fonts[\'Test\'][0].bold":');
+      expect(fn).toThrowError('Invalid value for "fonts/Test/0/bold":');
     });
 
     it('throws on missing data', () => {

--- a/test/graphics.test.ts
+++ b/test/graphics.test.ts
@@ -98,7 +98,7 @@ describe('graphics', () => {
     it(`throws for invalid point in polyline`, () => {
       const fn = () => parseGraphicsObject({ type: 'polyline', points: [{ x: 1, y: 'a' }] });
 
-      expect(fn).toThrowError(`Invalid value for "points[0].y": Expected number, got: 'a'`);
+      expect(fn).toThrowError(`Invalid value for "points/0/y": Expected number, got: 'a'`);
     });
 
     ['strokeColor', 'fillColor'].forEach((name) => {

--- a/test/images.test.ts
+++ b/test/images.test.ts
@@ -33,13 +33,13 @@ describe('images', () => {
     it('throws on invalid image definition', () => {
       const fn = () => parseImages({ foo: 23 });
 
-      expect(fn).toThrowError('Invalid value for "images[\'foo\']": Expected object, got: 23');
+      expect(fn).toThrowError('Invalid value for "images/foo": Expected object, got: 23');
     });
 
     it('throws on invalid image data', () => {
       const fn = () => parseImages({ foo: { data: 23 } });
 
-      expect(fn).toThrowError('Invalid value for "images[\'foo\'].data":');
+      expect(fn).toThrowError('Invalid value for "images/foo/data":');
     });
   });
 

--- a/test/layout.test.ts
+++ b/test/layout.test.ts
@@ -22,7 +22,7 @@ describe('layout', () => {
       const def = { defaultStyle: { fontSize: -1 }, content: [] };
 
       expect(() => layoutPages(def, resources)).toThrowError(
-        'Invalid value for "defaultStyle.fontSize":'
+        'Invalid value for "defaultStyle/fontSize":'
       );
     });
 

--- a/test/text.test.ts
+++ b/test/text.test.ts
@@ -46,7 +46,7 @@ describe('text', () => {
     it('checks content', () => {
       const content = [{ text: 'foo' }, { text: 23 }];
 
-      expect(() => parseContent(content, {})).toThrowError('Invalid value for "content[1].text":');
+      expect(() => parseContent(content, {})).toThrowError('Invalid value for "content/1/text":');
     });
   });
 

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -82,19 +82,7 @@ describe('types', () => {
 
       const fn = () => check(input, 'foo', nestedCheck);
 
-      expect(fn).toThrowError('Invalid value for "foo.bar": bad value');
-    });
-
-    it('handles bracket notation in nested error messages', () => {
-      const input = 23;
-      const bad = () => {
-        throw new TypeError('bad value');
-      };
-      const nestedCheck = () => check(input, '[0]', bad);
-
-      const fn = () => check(input, 'foo', nestedCheck);
-
-      expect(fn).toThrowError('Invalid value for "foo[0]": bad value');
+      expect(fn).toThrowError('Invalid value for "foo/bar": bad value');
     });
 
     it('throws for missing value', () => {


### PR DESCRIPTION
[RFC 6901] ("JSON Pointer") defines a string syntax for identifying a
specific value within a JSON document. Unlike JSON Path, this syntax
separates path segments by slashes, e.g. `/items/0/name`.

This syntax is simpler and more suitable to refer to a value in an error
messages than JSON Path, which is more targeted at defining search
queries. JSON Pointer is also advertised on the [JSON Schema] site and
used in [Ajv errors].

Use this syntax to assemble type errors for nested values.

[RFC 6901]: https://datatracker.ietf.org/doc/html/rfc6901
[JSON Schema]: https://json-schema.org/specification.html
[Ajv errors]: https://ajv.js.org/api.html#error-objects