### PR TITLE
✨ Support different page sizes

### DIFF
--- a/examples/sample.js
+++ b/examples/sample.js
@@ -23,6 +23,7 @@ export default {
   images: {
     liberty: { data: readFileSync('examples/liberty.jpg') },
   },
+  pageSize: 'A4',
   margin: { x: '2.5cm', top: '2.5cm', bottom: '2cm' },
   defaultStyle: {
     fontSize: 14,

--- a/src/content.ts
+++ b/src/content.ts
@@ -1,4 +1,5 @@
 import { namedColors } from './colors.js';
+import { paperSizes } from './page-sizes.js';
 
 /**
  * The complete definition of a document to create.
@@ -22,6 +23,15 @@ export type DocumentDefinition = {
    * The default style attributes to use in the document.
    */
   defaultStyle?: TextAttrs;
+  /**
+   * The page size of the document. Defaults to A4.
+   */
+  pageSize?: PaperSize | Size;
+  /**
+   * The orientation of the pages in the document. When this parameter is set, width and height
+   * of the given page size will be reversed if necessary to match the given orientation.
+   */
+  pageOrientation?: Orientation;
   /**
    * The page margins. Defaults to 50pt on each side.
    */
@@ -334,3 +344,12 @@ export type NamedColor = keyof typeof namedColors;
 export type HTMLColor = `#${string}`;
 
 export type Alignment = 'left' | 'right' | 'center';
+
+/**
+ * All named paper sizes are in portrait orientation.
+ */
+export type PaperSize = keyof typeof paperSizes;
+
+export type Orientation = 'portrait' | 'landscape';
+
+export type Size = { width: Length; height: Length };

--- a/src/document.ts
+++ b/src/document.ts
@@ -1,8 +1,10 @@
 import fontkit from '@pdf-lib/fontkit';
 import { PDFDict, PDFDocument, PDFHexString, PDFName } from 'pdf-lib';
 
+import { Size } from './box.js';
 import { embedFonts, Font, parseFonts } from './fonts.js';
 import { embedImages, Image, parseImages } from './images.js';
+import { applyOrientation, paperSizes, parseOrientation, parsePageSize } from './page-sizes.js';
 import {
   asArray,
   asDate,
@@ -18,6 +20,7 @@ import {
 export type Document = {
   fonts: Font[];
   images: Image[];
+  pageSize: Size;
   pdfDoc: PDFDocument;
 };
 
@@ -27,9 +30,10 @@ export async function createDocument(def: Obj): Promise<Document> {
 
   const fonts = await embedFonts(getFrom(def, 'fonts', parseFonts), pdfDoc);
   const images = await embedImages(getFrom(def, 'images', parseImages), pdfDoc);
-
+  const size = getFrom(def, 'pageSize', optional(parsePageSize)) ?? paperSizes.A4;
+  const orientation = getFrom(def, 'pageOrientation', optional(parseOrientation));
   setMetadata(getFrom(def, 'info', optional(parseInfo)), pdfDoc);
-  return { fonts, images, pdfDoc };
+  return { fonts, images, pageSize: applyOrientation(size, orientation), pdfDoc };
 }
 
 type Metadata = {

--- a/src/page-sizes.ts
+++ b/src/page-sizes.ts
@@ -1,0 +1,88 @@
+import { parseLength, Size } from './box.js';
+import { getFrom, isObject, required, typeError } from './types.js';
+
+export function parsePageSize(def?: unknown): Size {
+  if (typeof def === 'string') {
+    const size = paperSizes[def];
+    if (!size) throw typeError('valid paper size', def);
+    const { width, height } = size;
+    return { width, height };
+  }
+  if (isObject(def)) {
+    const width = getFrom(def, 'width', required(parseLength));
+    const height = getFrom(def, 'height', required(parseLength));
+    if (width <= 0) throw typeError('positive width', width);
+    if (height <= 0) throw typeError('positive height', height);
+    return { width, height };
+  }
+  throw typeError('valid page size', def);
+}
+
+export function parseOrientation(def?: unknown): 'portrait' | 'landscape' {
+  if (def === 'portrait' || def === 'landscape') return def;
+  throw typeError("'portrait' or 'landscape'", def);
+}
+
+export function applyOrientation(size: Size, orientation: 'portrait' | 'landscape'): Size {
+  const { width, height } = size;
+  if (orientation === 'portrait') {
+    return { width: Math.min(width, height), height: Math.max(width, height) };
+  }
+  if (orientation === 'landscape') {
+    return { width: Math.max(width, height), height: Math.min(width, height) };
+  }
+  return size;
+}
+
+export const paperSizes = {
+  '4A0': { width: 4767.87, height: 6740.79 },
+  '2A0': { width: 3370.39, height: 4767.87 },
+  A0: { width: 2383.94, height: 3370.39 },
+  A1: { width: 1683.78, height: 2383.94 },
+  A2: { width: 1190.55, height: 1683.78 },
+  A3: { width: 841.89, height: 1190.55 },
+  A4: { width: 595.28, height: 841.89 },
+  A5: { width: 419.53, height: 595.28 },
+  A6: { width: 297.64, height: 419.53 },
+  A7: { width: 209.76, height: 297.64 },
+  A8: { width: 147.4, height: 209.76 },
+  A9: { width: 104.88, height: 147.4 },
+  A10: { width: 73.7, height: 104.88 },
+  B0: { width: 2834.65, height: 4008.19 },
+  B1: { width: 2004.09, height: 2834.65 },
+  B2: { width: 1417.32, height: 2004.09 },
+  B3: { width: 1000.63, height: 1417.32 },
+  B4: { width: 708.66, height: 1000.63 },
+  B5: { width: 498.9, height: 708.66 },
+  B6: { width: 354.33, height: 498.9 },
+  B7: { width: 249.45, height: 354.33 },
+  B8: { width: 175.75, height: 249.45 },
+  B9: { width: 124.72, height: 175.75 },
+  B10: { width: 87.87, height: 124.72 },
+  C0: { width: 2599.37, height: 3676.54 },
+  C1: { width: 1836.85, height: 2599.37 },
+  C2: { width: 1298.27, height: 1836.85 },
+  C3: { width: 918.43, height: 1298.27 },
+  C4: { width: 649.13, height: 918.43 },
+  C5: { width: 459.21, height: 649.13 },
+  C6: { width: 323.15, height: 459.21 },
+  C7: { width: 229.61, height: 323.15 },
+  C8: { width: 161.57, height: 229.61 },
+  C9: { width: 113.39, height: 161.57 },
+  C10: { width: 79.37, height: 113.39 },
+  RA0: { width: 2437.8, height: 3458.27 },
+  RA1: { width: 1729.13, height: 2437.8 },
+  RA2: { width: 1218.9, height: 1729.13 },
+  RA3: { width: 864.57, height: 1218.9 },
+  RA4: { width: 609.45, height: 864.57 },
+  SRA0: { width: 2551.18, height: 3628.35 },
+  SRA1: { width: 1814.17, height: 2551.18 },
+  SRA2: { width: 1275.59, height: 1814.17 },
+  SRA3: { width: 907.09, height: 1275.59 },
+  SRA4: { width: 637.8, height: 907.09 },
+  Executive: { width: 521.86, height: 756.0 },
+  Folio: { width: 612.0, height: 936.0 },
+  Legal: { width: 612.0, height: 1008.0 },
+  Letter: { width: 612.0, height: 792.0 },
+  Tabloid: { width: 792.0, height: 1224.0 },
+};

--- a/test/page-sizes.test.ts
+++ b/test/page-sizes.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from '@jest/globals';
+
+import {
+  applyOrientation,
+  paperSizes,
+  parseOrientation,
+  parsePageSize,
+} from '../src/page-sizes.js';
+
+describe('page-sizes', () => {
+  describe('parsePageSize', () => {
+    it('supports known paper sizes', () => {
+      expect(parsePageSize('A4')).toEqual(paperSizes.A4);
+      expect(parsePageSize('2A0')).toEqual(paperSizes['2A0']);
+    });
+
+    it('throws on unsupported paper size', () => {
+      expect(() => parsePageSize('foo')).toThrowError("Expected valid paper size, got: 'foo'");
+      expect(() => parsePageSize('a4')).toThrowError("Expected valid paper size, got: 'a4'");
+    });
+
+    it('supports width and height', () => {
+      expect(parsePageSize({ width: 23, height: 42 })).toEqual({ width: 23, height: 42 });
+      expect(parsePageSize({ width: '23cm', height: '42cm' })).toEqual({
+        width: (23 * 72) / 2.54,
+        height: (42 * 72) / 2.54,
+      });
+    });
+
+    it('throws on missing width or height', () => {
+      expect(() => parsePageSize({ width: 23 })).toThrowError('Missing value for "height"');
+      expect(() => parsePageSize({ height: 42 })).toThrowError('Missing value for "width"');
+    });
+
+    it('throws on zero or negative values for width or height', () => {
+      expect(() => parsePageSize({ width: 0, height: 42 })).toThrowError(
+        'Expected positive width, got: 0'
+      );
+      expect(() => parsePageSize({ width: -1, height: 42 })).toThrowError(
+        'Expected positive width, got: -1'
+      );
+      expect(() => parsePageSize({ width: 23, height: 0 })).toThrowError(
+        'Expected positive height, got: 0'
+      );
+      expect(() => parsePageSize({ width: 23, height: -1 })).toThrowError(
+        'Expected positive height, got: -1'
+      );
+    });
+
+    it('throws on invalid type', () => {
+      expect(() => parsePageSize(23)).toThrowError('Expected valid page size, got: 23');
+    });
+  });
+
+  describe('parseOrientation', () => {
+    it('supports orientation identifiers', () => {
+      expect(parseOrientation('portrait')).toEqual('portrait');
+      expect(parseOrientation('landscape')).toEqual('landscape');
+    });
+
+    it('throws on unsupported orientation', () => {
+      expect(() => parseOrientation('foo')).toThrowError(
+        "Expected 'portrait' or 'landscape', got: 'foo'"
+      );
+    });
+
+    it('throws on invalid type', () => {
+      expect(() => parseOrientation(23)).toThrowError(
+        "Expected 'portrait' or 'landscape', got: 23"
+      );
+      expect(() => parseOrientation(null)).toThrowError(
+        "Expected 'portrait' or 'landscape', got: null"
+      );
+    });
+  });
+
+  describe('applyOrientation', () => {
+    it('returns size adjusted to portrait orientation', () => {
+      expect(applyOrientation({ width: 23, height: 42 }, 'portrait')).toEqual({
+        width: 23,
+        height: 42,
+      });
+      expect(applyOrientation({ width: 42, height: 23 }, 'portrait')).toEqual({
+        width: 23,
+        height: 42,
+      });
+    });
+
+    it('returns size adjusted to landscape orientation', () => {
+      expect(applyOrientation({ width: 23, height: 42 }, 'landscape')).toEqual({
+        width: 42,
+        height: 23,
+      });
+      expect(applyOrientation({ width: 42, height: 23 }, 'landscape')).toEqual({
+        width: 42,
+        height: 23,
+      });
+    });
+
+    it('returns unmodified size if orientation is null', () => {
+      expect(applyOrientation({ width: 23, height: 42 }, null)).toEqual({
+        width: 23,
+        height: 42,
+      });
+      expect(applyOrientation({ width: 42, height: 23 }, null)).toEqual({
+        width: 42,
+        height: 23,
+      });
+    });
+  });
+});


### PR DESCRIPTION
The page size of the PDF was fixed to A4. This change allows creating
PDF documents with different page sizes.

Introduce a new property `pageSize` in the document definition that
allows to set the size for all pages in the document. Different sizes
for individual pages are not yet supported.

The page size is accepted either as an object with `width` and `height`
attributes or a string with a well-known paper format, e.g. "A4". Format
strings are case sensitive, i.e. `Letter` is supported, but `letteR` is
not.
To allow for landscape orientation, the modifier `-landscape` can be
appended to a format string. All supported paper sizes are in portrait
orientation, however, for consistency, allow also `-portrait`.

Page sizes have been copied from pdf-lib to ensure the API remains
constant.