### PR TITLE
✨ Support block attributes to control page breaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Graphics shape type `circle`.
 * Attributes `lineOpacity` and `fillOpacity` on graphics shapes.
 * Attribute `padding` on *all* block types.
+* Attributes `breakBefore` and `breakAfter` on top-level blocks.
 * Margins and paddings are highlighted when guides are enabled.
 
 ### Fixed

--- a/examples/sample.js
+++ b/examples/sample.js
@@ -308,6 +308,7 @@ export default {
         })),
       ],
       margin: { bottom: 10 },
+      breakBefore: 'always',
     },
     ...range(10).map((n) => ({
       text:

--- a/src/content.ts
+++ b/src/content.ts
@@ -210,6 +210,22 @@ export type BlockAttrs = {
    * A function can be passed to take the final size of the block into account.
    */
   graphics?: Shape[] | ((info: BlockInfo) => Shape[]);
+  /**
+   * Controls whether a page break may occur before the block. Since page breaks are only inserted
+   * between top-level blocks, this attribute is ignored on nested blocks.
+   * - `auto` (default): Insert a page break when needed.
+   * - `always`: Always insert a page break before this block.
+   * - `avoid`: Do not insert a page break before this block if it can be avoided.
+   */
+  breakBefore?: 'auto' | 'always' | 'avoid';
+  /**
+   * Controls whether a page break may occur after the block. Since page breaks are only inserted
+   * between top-level blocks, this attribute is ignored on nested blocks.
+   * - `auto` (default): Insert a page break when needed.
+   * - `always`: Always insert a page break after this block.
+   * - `avoid`: Do not insert a page break after this block if it can be avoided.
+   */
+  breakAfter?: 'auto' | 'always' | 'avoid';
 };
 
 export type PageInfo = {

--- a/src/guides.ts
+++ b/src/guides.ts
@@ -3,7 +3,7 @@ import { rgb } from 'pdf-lib';
 import { ZERO_EDGES } from './box.js';
 import { Frame, TextRowObject } from './layout.js';
 import { Block } from './read-block.js';
-import { GraphicsObject, LineObject, RectObject } from './read-graphics.js';
+import { CircleObject, GraphicsObject, LineObject, RectObject } from './read-graphics.js';
 
 export function createPageGuides(frame: Frame): GraphicsObject {
   const { width, height } = frame;
@@ -13,22 +13,28 @@ export function createPageGuides(frame: Frame): GraphicsObject {
 }
 
 export function createFrameGuides(frame: Frame, block: Block): GraphicsObject {
-  const { width, height } = frame;
+  const { width: w, height: h } = frame;
   const { left: ml, right: mr, top: mt, bottom: mb } = block.margin ?? ZERO_EDGES;
   const { left: pl, right: pr, top: pt, bottom: pb } = block.padding ?? ZERO_EDGES;
+  const { breakBefore: bb, breakAfter: ba } = block;
   const stroke = { lineColor: rgb(0, 0, 0), lineWidth: 0.5, lineOpacity: 0.25 };
+  const fill = { fillColor: rgb(0, 0, 0), fillOpacity: 0.25 };
   const mFill = { fillColor: rgb(0.9, 0.8, 0.3), fillOpacity: 0.2 };
   const pFill = { fillColor: rgb(0.2, 0.2, 0.7), fillOpacity: 0.2 };
   const shapes = [
-    rect({ x: 0, y: 0, width, height, ...stroke }),
-    mt && rect({ x: -ml, y: -mt, width: width + ml + mr, height: mt, ...mFill }),
-    ml && rect({ x: -ml, y: 0, width: ml, height, ...mFill }),
-    mr && rect({ x: width, y: 0, width: mr, height, ...mFill }),
-    mb && rect({ x: -ml, y: height, width: width + ml + mr, height: mb, ...mFill }),
-    pt && rect({ x: 0, y: 0, width, height: pt, ...pFill }),
-    pl && rect({ x: 0, y: pt, width: pl, height: height - pt - pb, ...pFill }),
-    pr && rect({ x: width - pr, y: pt, width: pr, height: height - pt - pb, ...pFill }),
-    pb && rect({ x: 0, y: height - pb, width, height: pb, ...pFill }),
+    rect({ x: 0, y: 0, width: w, height: h, ...stroke }),
+    mt && rect({ x: -ml, y: -mt, width: w + ml + mr, height: mt, ...mFill }),
+    ml && rect({ x: -ml, y: 0, width: ml, height: h, ...mFill }),
+    mr && rect({ x: w, y: 0, width: mr, height: h, ...mFill }),
+    mb && rect({ x: -ml, y: h, width: w + ml + mr, height: mb, ...mFill }),
+    pt && rect({ x: 0, y: 0, width: w, height: pt, ...pFill }),
+    pl && rect({ x: 0, y: pt, width: pl, height: h - pt - pb, ...pFill }),
+    pr && rect({ x: w - pr, y: pt, width: pr, height: h - pt - pb, ...pFill }),
+    pb && rect({ x: 0, y: h - pb, width: w, height: pb, ...pFill }),
+    bb === 'avoid' && circle({ cx: 5, cy: 0, r: 3, ...fill }),
+    bb === 'always' && rect({ x: 0, y: -3, width: 30, height: 3, ...fill }),
+    ba === 'avoid' && circle({ cx: w - 5, cy: h, r: 3, ...fill }),
+    ba === 'always' && rect({ x: w - 30, y: h, width: 30, height: 3, ...fill }),
   ].filter(Boolean);
   return { type: 'graphics', shapes };
 }
@@ -47,6 +53,10 @@ export function createRowGuides({ x, y, width, height, baseline }: TextRowObject
 
 function rect(args: Omit<RectObject, 'type'>): RectObject {
   return { type: 'rect', ...args };
+}
+
+function circle(args: Omit<CircleObject, 'type'>): CircleObject {
+  return { type: 'circle', ...args };
 }
 
 function line(args: Omit<LineObject, 'type'>): LineObject {

--- a/src/read-block.ts
+++ b/src/read-block.ts
@@ -60,6 +60,8 @@ type BlockAttrs = {
   height?: number;
   id?: string;
   graphics?: (info: BlockInfo) => Shape[];
+  breakBefore?: 'auto' | 'always' | 'avoid';
+  breakAfter?: 'auto' | 'always' | 'avoid';
 };
 
 export type BlockInfo = {
@@ -144,7 +146,9 @@ function readBlockAttrs(input: Obj): BlockAttrs {
     height: optional(parseLength),
     id: optional(types.string()),
     graphics: optional(dynamic(types.array(readShape), 'graphics')),
-  });
+    breakBefore: optional(types.string({ enum: ['auto', 'always', 'avoid'] })),
+    breakAfter: optional(types.string({ enum: ['auto', 'always', 'avoid'] })),
+  }) as BlockAttrs;
 }
 
 export function readTextAttrs(input: Obj): TextAttrs {


### PR DESCRIPTION
Support the attributes `breakBefore` and `breakAfter` on top-level
blocks to control whether a page break should or should not be inserted
before or after a block. These attributes are based on the CSS
attributes [break-before] and [break-after] which replace the deprecated
`page-break-before` and `page-break-after`. The new attributes control
not only page breaks, but also column breaks. Even though the latter is
not yet required, we may want to extend these attributes later.

Currently, only the attributes `auto`, `avoid`, and `always` are
supported, with `auto` being the default.

In case of a conflict, e.g. when a block with `breakAfter: 'avoid'` is
followed by a block with `breakBefore: 'always'`, let `always` take
precedence and insert a page break.

When guides are enabled, indicate enforced page breaks by a small
horizontal bar above the frame on the left (for `breakBefore: 'always'`)
or below the frame on the right (for `breakAfter: 'always'`).
Also indicate `avoid` by a small dot on the upper or lower edge of the
frame.

[break-before]: https://developer.mozilla.org/en-US/docs/Web/CSS/break-before
[break-after]: https://developer.mozilla.org/en-US/docs/Web/CSS/break-after