### PR TITLE
✨ Support custom data in document catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+* Attribute `customData` to include custom data in the PDF *document catalog*.
+
 ## [0.3.1] - 2022-08-25
 
 ### Fixed

--- a/src/content.ts
+++ b/src/content.ts
@@ -51,6 +51,14 @@ export type DocumentDefinition = {
    * Metadata to include in the PDF's *document information dictionary*.
    */
   info?: InfoAttrs & CustomInfoAttrs;
+  /**
+   * Custom data to be added to the PDF *document catalog*. This attribute should only be used by
+   * PDF applications that need to include custom data in a PDF document.
+   * To avoid name collisions, keys should be prefixed with `XX`.
+   *
+   * See [PDF 1.7, Appendix E - PDF Name Registry](https://archive.org/details/pdf1.7/page/n1017/mode/2up)
+   */
+  customData?: Record<string, string | Uint8Array>;
   dev?: {
     /**
      * Whether to draw a thin colored rectangle around each rendered frame.

--- a/src/document.ts
+++ b/src/document.ts
@@ -22,6 +22,9 @@ export async function createDocument(def: DocumentDefinition): Promise<Document>
   const images = await embedImages(def.images ?? [], pdfDoc);
   const pageSize = applyOrientation(def.pageSize ?? paperSizes.A4, def.pageOrientation);
   setMetadata(def.info, pdfDoc);
+  if (def.customData) {
+    setCustomData(def.customData, pdfDoc);
+  }
   const guides = !!def.dev?.guides;
   return { fonts, images, pageSize, pdfDoc, guides };
 }
@@ -69,6 +72,14 @@ function setMetadata(info: Metadata, doc: PDFDocument) {
     for (const [key, value] of Object.entries(info.custom)) {
       dict.set(PDFName.of(key), PDFHexString.fromText(value));
     }
+  }
+}
+
+function setCustomData(data: Record<string, string | Uint8Array>, doc: PDFDocument) {
+  for (const [key, value] of Object.entries(data)) {
+    const stream = doc.context.stream(value);
+    const ref = doc.context.register(stream);
+    doc.catalog.set(PDFName.of(key), ref);
   }
 }
 

--- a/src/read-document.ts
+++ b/src/read-document.ts
@@ -3,7 +3,7 @@ import { FontDef, readFonts } from './fonts.js';
 import { ImageDef, readImages } from './images.js';
 import { parseOrientation, parsePageSize } from './page-sizes.js';
 import { Block, readBlock, readInheritableAttrs, TextAttrs } from './read-block.js';
-import { dynamic, optional, readAs, readObject, required, types } from './types.js';
+import { dynamic, optional, readAs, readObject, required, typeError, types } from './types.js';
 
 export type DocumentDefinition = {
   fonts?: FontDef[];
@@ -17,6 +17,7 @@ export type DocumentDefinition = {
   header?: (info: PageInfo) => Block;
   footer?: (info: PageInfo) => Block;
   content: Block[];
+  customData?: Record<string, string | Uint8Array>;
 };
 
 export type Metadata = {
@@ -46,8 +47,9 @@ export function readDocumentDefinition(input: unknown): DocumentDefinition {
     defaultStyle: optional(readInheritableAttrs),
     margin: optional(parseEdges),
     dev: optional(types.object({ guides: optional(types.boolean()) })),
+    customData: optional(readCustomData),
   });
-  const tBlock = (block) => readBlock(block, def1.defaultStyle);
+  const tBlock = (block: unknown) => readBlock(block, def1.defaultStyle);
   const def2 = readObject(input, {
     header: optional(dynamic(tBlock)),
     footer: optional(dynamic(tBlock)),
@@ -73,4 +75,15 @@ function readInfo(input: unknown): Metadata {
       .map(([key, value]) => [key, readAs(value, key, types.string())])
   );
   return Object.keys(custom).length ? { ...obj, custom } : obj;
+}
+
+function readCustomData(input: unknown) {
+  const readValue = (input: unknown) => {
+    if (typeof input === 'string') return input;
+    if (typeof input === 'object' && input instanceof Uint8Array) return input;
+    throw typeError('string or Uint8Array', input);
+  };
+  return Object.fromEntries(
+    Object.entries(readObject(input)).map(([key, value]) => [key, readAs(value, key, readValue)])
+  );
 }

--- a/test/document.test.ts
+++ b/test/document.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from '@jest/globals';
-import { PDFDict, PDFHexString, PDFName, PDFString } from 'pdf-lib';
+import { PDFDict, PDFHexString, PDFName, PDFStream, PDFString } from 'pdf-lib';
 
 import { createDocument } from '../src/document.js';
 
@@ -37,6 +37,22 @@ describe('document', () => {
       expect(getInfo('CreationDate')).toEqual(PDFString.fromDate(new Date(23)));
       expect(getInfo('foo')).toEqual(PDFHexString.fromText('foo-value'));
       expect(getInfo('bar')).toEqual(PDFHexString.fromText('bar-value'));
+    });
+
+    it('renders custom data', async () => {
+      const def = {
+        content: [],
+        customData: {
+          XXFoo: 'Foo',
+          XXBar: Uint8Array.of(1, 2, 3),
+        },
+      };
+
+      const doc = await createDocument(def);
+
+      const lookup = (name: string) => doc.pdfDoc.catalog.lookup(PDFName.of(name)) as PDFStream;
+      expect(lookup('XXFoo').getContentsString()).toBe('Foo');
+      expect(lookup('XXBar').getContents()).toEqual(Uint8Array.of(1, 2, 3));
     });
   });
 });

--- a/test/read-document.test.ts
+++ b/test/read-document.test.ts
@@ -125,5 +125,21 @@ describe('read-document', () => {
         });
       });
     });
+
+    it('accepts customData', () => {
+      const customData = { foo: 'abc', bar: Uint8Array.of(1, 2, 3) };
+
+      const def = readDocumentDefinition({ ...input, customData });
+
+      expect(def.customData).toEqual(def.customData);
+    });
+
+    it('checks customData', () => {
+      const customData = { foo: 'abc', bar: 23 };
+
+      expect(() => readDocumentDefinition({ ...input, customData })).toThrowError(
+        'Invalid value for "customData/bar": Expected string or Uint8Array, got: 23'
+      );
+    });
   });
 });


### PR DESCRIPTION
PDF applications may include custom attributes in any object in the PDF document, except for the file trailer dictionary. Custom keys should be prefixed with `XX` [1].

The `info` attribute already allows for custom meta data to be added to the `Info` dictionary, however, only strings are supported in this data structure.

To allow for including larger blocks of binary data in a document, provide another attribute `customData` that accepts an object whose values can be strings or Uint8Arrays. Data added to this attribute will be included as stream objects and referenced in the *document catalog*.

Do not enforce the `XX` prefix, but leave the name to the application for maximum flexibility.

[1] See PDF 1.7, Appendix E - PDF Name Registry
https://archive.org/details/pdf1.7/page/n1017/mode/2up