### PR TITLE
🐛 Fix error when rendering header without footer

### DIFF
--- a/src/layout.ts
+++ b/src/layout.ts
@@ -82,7 +82,7 @@ export function layoutPages(def: DocumentDefinition, doc: Document): Page[] {
   pages.forEach((page, idx) => {
     const pageInfo = { pageCount: pages.length, pageNumber: idx + 1, pageSize: doc.pageSize };
     page.header = def.header && layoutHeader(def.header(pageInfo), doc);
-    page.footer = def.header && layoutFooter(def.footer(pageInfo), doc);
+    page.footer = def.footer && layoutFooter(def.footer(pageInfo), doc);
   });
   return pages.map(pickDefined) as Page[];
 }

--- a/test/layout.test.ts
+++ b/test/layout.test.ts
@@ -57,6 +57,49 @@ describe('layout', () => {
       ]);
     });
 
+    it('lays out header', () => {
+      const def = readDocumentDefinition({
+        margin: 50,
+        content: [{ text: 'content' }],
+        header: { text: 'header', margin: 20, fontSize: 10 },
+      });
+      const pageWidth = doc.pageSize.width;
+
+      const pages = layoutPages(def, doc);
+
+      expect(pages[0].header).toEqual(
+        objectContaining({
+          x: 20,
+          y: 20,
+          width: pageWidth - 40,
+          height: 12,
+        })
+      );
+      expect(pages[0].footer).toBeUndefined();
+    });
+
+    it('lays out footer', () => {
+      const def = readDocumentDefinition({
+        margin: 50,
+        content: [{ text: 'content' }],
+        footer: { text: 'footer', margin: 20, fontSize: 10 },
+      });
+      const pageWidth = doc.pageSize.width;
+      const pageHeight = doc.pageSize.height;
+
+      const pages = layoutPages(def, doc);
+
+      expect(pages[0].header).toBeUndefined();
+      expect(pages[0].footer).toEqual(
+        objectContaining({
+          x: 20,
+          y: pageHeight - 20 - 12,
+          width: pageWidth - 40,
+          height: 12,
+        })
+      );
+    });
+
     it('lays out header and footer', () => {
       const def = readDocumentDefinition({
         margin: 50,


### PR DESCRIPTION
When rendering a document definition that includes a `header` but not a `footer`, pdfmkr would throw an error due a typo in the layout code.

This change fixes that error.