### PR TITLE
💥 Make page margin relative to header/footer, bump to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## [Unreleased]
+## [0.4.0] - Unreleased
+
+### Breaking changes
+
+* Page margins are now relative to the header and footer to let the
+  contents adjust to a dynamic header and footer height.
 
 ### Added
 
@@ -75,3 +80,8 @@ First public version.
 [0.1.0]: https://github.com/eclipsesource/pdf-maker/releases/tag/v0.1.0
 [0.2.0]: https://github.com/eclipsesource/pdf-maker/releases/tag/v0.2.0
 [0.3.0]: https://github.com/eclipsesource/pdf-maker/releases/tag/v0.3.0
+[0.3.0]: https://github.com/eclipsesource/pdf-maker/releases/tag/v0.3.0
+[0.3.1]: https://github.com/eclipsesource/pdf-maker/releases/tag/v0.3.1
+[0.3.2]: https://github.com/eclipsesource/pdf-maker/releases/tag/v0.3.2
+[0.3.3]: https://github.com/eclipsesource/pdf-maker/releases/tag/v0.3.3
+[0.4.0]: https://github.com/eclipsesource/pdf-maker/releases/tag/v0.4.0

--- a/examples/sample.js
+++ b/examples/sample.js
@@ -24,7 +24,7 @@ export default {
     liberty: { data: readFileSync('examples/liberty.jpg') },
   },
   pageSize: 'A4',
-  margin: { x: '2.5cm', top: '2.5cm', bottom: '2cm' },
+  margin: { x: '2.5cm', y: '0.5cm' },
   defaultStyle: {
     fontSize: 14,
   },
@@ -33,7 +33,7 @@ export default {
     margin: { x: '2.5cm', top: '1cm' },
   },
   footer: ({ pageNumber, pageCount }) => ({
-    text: `${pageNumber}/${pageCount}`,
+    text: `${pageNumber}/${pageCount ?? 0}`,
     textAlign: 'right',
     margin: { x: '2.5cm', bottom: '1cm' },
   }),
@@ -296,7 +296,7 @@ export default {
     },
     {
       columns: [
-        { image: 'liberty', padding: 5 },
+        { image: 'liberty', padding: 5, width: 100, verticalAlign: 'middle' },
         {
           rows: [
             { image: 'liberty', height: 75, imageAlign: 'left' },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pdfmkr",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pdfmkr",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@pdf-lib/fontkit": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdfmkr",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "Generate PDF documents and from JavaScript objects",
   "license": "MIT",
   "repository": {

--- a/src/content.ts
+++ b/src/content.ts
@@ -33,7 +33,13 @@ export type DocumentDefinition = {
    */
   pageOrientation?: Orientation;
   /**
-   * The page margins. Defaults to 50pt on each side.
+   * The margin to leave around the page content area, relative to header and footer.
+   * That is, if a header is specified, the top margin defines the vertical distance from the
+   * header, otherwise from the top of the page.
+   * The bottom margin defines the vertical distance from the footer or, if there is no footer,
+   * from the bottom of the page.
+   *
+   * Defaults to `50pt` on each side.
    */
   margin?: Length | BoxLengths;
   /**
@@ -61,7 +67,9 @@ export type DocumentDefinition = {
   customData?: Record<string, string | Uint8Array>;
   dev?: {
     /**
-     * Whether to draw a thin colored rectangle around each rendered frame.
+     * When set to true, additional guides are drawn to help analyzing the layout.
+     * A thin rectangle is drawn around each rendered frame. Margins are given a semi-transparent
+     * yellow background and padding areas are shown in blue.
      */
     guides?: boolean;
   };
@@ -207,6 +215,10 @@ export type BlockAttrs = {
    */
   textAlign?: Alignment;
   /**
+   * Aligns this block vertically within a columns block.
+   */
+  verticalAlign?: 'top' | 'middle' | 'bottom';
+  /**
    * An optional *unique* id for the element. When an `id` is specified, an anchor with this id
    * will be included in the PDF document that can be used to refer to this element using the text
    * attribute `link`.
@@ -238,17 +250,19 @@ export type BlockAttrs = {
 
 export type PageInfo = {
   /**
+   * The size of the current page in pt.
+   */
+  readonly pageSize: { width: number; height: number };
+  /**
    * The number of the current page, starting at 1.
    */
   readonly pageNumber: number;
   /**
    * The total number of pages.
+   * This value is only available after the layout of the entire document has finished.
+   * Before that, it is `undefined`.
    */
-  readonly pageCount: number;
-  /**
-   * The size of the current page in pt.
-   */
-  readonly pageSize: { width: number; height: number };
+  readonly pageCount?: number;
 };
 
 export type BlockInfo = {

--- a/src/guides.ts
+++ b/src/guides.ts
@@ -5,36 +5,38 @@ import { Frame, TextRowObject } from './layout.js';
 import { Block } from './read-block.js';
 import { CircleObject, GraphicsObject, LineObject, RectObject, Shape } from './read-graphics.js';
 
-export function createPageGuides(frame: Frame): GraphicsObject {
-  const { width, height } = frame;
-  const stroke = { lineColor: rgb(0.8, 0.3, 0.1), lineWidth: 5, lineOpacity: 0.2 };
-  const shapes = [rect({ x: -2.5, y: -2.5, width: width + 5, height: height + 5, ...stroke })];
-  return { type: 'graphics', shapes };
-}
-
-export function createFrameGuides(frame: Frame, block: Block): GraphicsObject {
+export function createFrameGuides(
+  frame: Frame,
+  block: Block & { isPage?: boolean }
+): GraphicsObject {
   const { width: w, height: h } = frame;
   const { left: ml, right: mr, top: mt, bottom: mb } = block.margin ?? ZERO_EDGES;
   const { left: pl, right: pr, top: pt, bottom: pb } = block.padding ?? ZERO_EDGES;
-  const { breakBefore: bb, breakAfter: ba } = block;
+  const { breakBefore: bb, breakAfter: ba, isPage: page } = block;
   const stroke = { lineColor: rgb(0, 0, 0), lineWidth: 0.5, lineOpacity: 0.25 };
   const fill = { fillColor: rgb(0, 0, 0), fillOpacity: 0.25 };
-  const mFill = { fillColor: rgb(0.9, 0.8, 0.3), fillOpacity: 0.2 };
-  const pFill = { fillColor: rgb(0.2, 0.2, 0.7), fillOpacity: 0.2 };
+  const mFill = { fillColor: rgb(0.9, 0.8, 0.3), fillOpacity: 0.15 };
+  const pFill = { fillColor: rgb(0.2, 0.2, 0.7), fillOpacity: 0.15 };
   const shapes = [
     rect({ x: 0, y: 0, width: w, height: h, ...stroke }),
+    // margin
     mt && rect({ x: -ml, y: -mt, width: w + ml + mr, height: mt, ...mFill }),
     ml && rect({ x: -ml, y: 0, width: ml, height: h, ...mFill }),
     mr && rect({ x: w, y: 0, width: mr, height: h, ...mFill }),
     mb && rect({ x: -ml, y: h, width: w + ml + mr, height: mb, ...mFill }),
+    // padding
     pt && rect({ x: 0, y: 0, width: w, height: pt, ...pFill }),
     pl && rect({ x: 0, y: pt, width: pl, height: h - pt - pb, ...pFill }),
     pr && rect({ x: w - pr, y: pt, width: pr, height: h - pt - pb, ...pFill }),
     pb && rect({ x: 0, y: h - pb, width: w, height: pb, ...pFill }),
+    // indicators for breakBefore and breakAfter
     bb === 'avoid' && circle({ cx: 5, cy: 0, r: 3, ...fill }),
     bb === 'always' && rect({ x: 0, y: -3, width: 30, height: 3, ...fill }),
     ba === 'avoid' && circle({ cx: w - 5, cy: h, r: 3, ...fill }),
     ba === 'always' && rect({ x: w - 30, y: h, width: 30, height: 3, ...fill }),
+    // for pages, separator lines for header and footer
+    page && line({ x1: -ml, y1: -mt, x2: w + mr + ml, y2: -mt, ...stroke }),
+    page && line({ x1: -ml, y1: h + mb, x2: w + mr + ml, y2: h + mb, ...stroke }),
   ].filter(Boolean) as Shape[];
   return { type: 'graphics', shapes };
 }

--- a/src/layout-columns.ts
+++ b/src/layout-columns.ts
@@ -26,9 +26,17 @@ export function layoutColumnsContent(block: ColumnsBlock, box: Box, doc: Documen
       height: column.height ?? box.height,
     };
     colX += colWidth + margin.right;
-    const block = layoutBlock(column, colBox, doc);
-    children.push(block);
-    maxColHeight = Math.max(maxColHeight, block.height + margin.top + margin.bottom);
+    const frame = layoutBlock(column, colBox, doc);
+    children.push(frame);
+    maxColHeight = Math.max(maxColHeight, frame.height + margin.top + margin.bottom);
+  });
+  block.columns.forEach((column, idx) => {
+    const child = children[idx];
+    if (column.verticalAlign === 'middle') {
+      child.y += (maxColHeight - child.height) / 2;
+    } else if (column.verticalAlign === 'bottom') {
+      child.y += maxColHeight - child.height;
+    }
   });
   return {
     children,

--- a/src/read-block.ts
+++ b/src/read-block.ts
@@ -61,6 +61,7 @@ type BlockAttrs = {
   height?: number;
   id?: string;
   graphics?: (info: BlockInfo) => Shape[];
+  verticalAlign?: 'top' | 'middle' | 'bottom';
   breakBefore?: 'auto' | 'always' | 'avoid';
   breakAfter?: 'auto' | 'always' | 'avoid';
 };
@@ -147,6 +148,7 @@ function readBlockAttrs(input: Obj): BlockAttrs {
     height: optional(parseLength),
     id: optional(types.string()),
     graphics: optional(dynamic(types.array(readShape), 'graphics')),
+    verticalAlign: optional(types.string({ enum: ['top', 'middle', 'bottom'] })),
     breakBefore: optional(types.string({ enum: ['auto', 'always', 'avoid'] })),
     breakAfter: optional(types.string({ enum: ['auto', 'always', 'avoid'] })),
   }) as BlockAttrs;

--- a/src/read-document.ts
+++ b/src/read-document.ts
@@ -32,9 +32,9 @@ export type Metadata = {
 };
 
 export type PageInfo = {
-  pageNumber: number;
-  pageCount: number;
   pageSize: { width: number; height: number };
+  pageNumber: number;
+  pageCount?: number;
 };
 
 export function readDocumentDefinition(input: unknown): DocumentDefinition {

--- a/test/layout-columns.test.ts
+++ b/test/layout-columns.test.ts
@@ -135,6 +135,28 @@ describe('layout-columns', () => {
         height: 27,
       });
     });
+
+    it('respects vertical alignment', () => {
+      const columns: Block[] = [
+        { text: [span('Column 1')], height: 100 },
+        { text: [span('Column 2')], verticalAlign: 'top' },
+        { text: [span('Column 3')], verticalAlign: 'middle' },
+        { text: [span('Column 4')], verticalAlign: 'bottom' },
+      ];
+      const block = { columns };
+
+      const frame = layoutColumnsContent(block, box, doc);
+
+      expect(frame).toEqual({
+        children: [
+          objectContaining({ y: box.y, height: 100 }),
+          objectContaining({ y: box.y, height: 12 }),
+          objectContaining({ y: box.y + (100 - 12) / 2, height: 12 }),
+          objectContaining({ y: box.y + 100 - 12, height: 12 }),
+        ],
+        height: 100,
+      });
+    });
   });
 });
 

--- a/test/read-block.test.ts
+++ b/test/read-block.test.ts
@@ -20,6 +20,7 @@ describe('read-block', () => {
         margin: 5,
         width: '50pt',
         height: '80pt',
+        verticalAlign: 'middle',
         graphics: [{ type: 'rect', x: 1, y: 2, width: 3, height: 4 }],
       };
 
@@ -30,6 +31,7 @@ describe('read-block', () => {
         margin: { left: 5, right: 5, top: 5, bottom: 5 },
         width: 50,
         height: 80,
+        verticalAlign: 'middle',
         graphics: expect.any(Function),
       });
     });
@@ -94,7 +96,7 @@ describe('read-block', () => {
   });
 
   describe('readTextBlock', () => {
-    it('includes all properties of a blocks', () => {
+    it('includes all block attributes', () => {
       const input = {
         text: 'foo',
         graphics: [{ type: 'rect', x: 1, y: 2, width: 3, height: 4 }],
@@ -102,6 +104,7 @@ describe('read-block', () => {
         padding: 6,
         width: '50pt',
         height: '80pt',
+        verticalAlign: 'middle',
       };
 
       const result = readTextBlock(input);
@@ -113,6 +116,7 @@ describe('read-block', () => {
         padding: { left: 6, right: 6, top: 6, bottom: 6 },
         width: 50,
         height: 80,
+        verticalAlign: 'middle',
       });
     });
 
@@ -159,6 +163,12 @@ describe('read-block', () => {
       const input = { text: [], height: 'foo' };
 
       expect(() => readTextBlock(input)).toThrowError('Invalid value for "height":');
+    });
+
+    it('checks verticalAlign', () => {
+      const input = { text: [], verticalAlign: 'foo' };
+
+      expect(() => readTextBlock(input)).toThrowError('Invalid value for "verticalAlign":');
     });
   });
 


### PR DESCRIPTION
The height of the header and the footer can be dynamic, but the page content used to be positioned relative to the edges of the page which could lead to an overlap.

This commit makes the page margin relative to the header and footer to let the page contents adjust to a dynamic header and footer height. The larger the header and footer, the less space is available for the page content. However, it is still possible to define a static layout by setting a fixed height on the header and footer.

This change requires to layout the header and footer first. However, at this point, the total page count is not yet known. Therefore, the header and footer are rendered twice, once to determine their size, and once again after all pages have been laid out to insert the total page count. This is only done if the header or footer is defined as a function.

Bump version to 0.4.0 to account for the breaking change.