### PR TITLE
♻️ Rename function related to ext graphics state

### DIFF
--- a/src/page.ts
+++ b/src/page.ts
@@ -35,14 +35,14 @@ export function getPageImage(page: Page, image: PDFImage): PDFName {
   return page.images[key];
 }
 
-type GraphicsState = { ca: number; CA: number };
+type ExtGraphicsParams = { ca: number; CA: number };
 
-export function getPageGraphicsState(page: Page, graphicsState: GraphicsState): PDFName {
+export function getExtGraphicsState(page: Page, params: ExtGraphicsParams): PDFName {
   if (!page.pdfPage) throw new Error('Page not initialized');
   page.extGStates ??= {};
-  const key = `CA:${graphicsState.CA},ca:${graphicsState.ca}`;
+  const key = `CA:${params.CA},ca:${params.ca}`;
   if (!(key in page.extGStates)) {
-    const dict = page.pdfPage.doc.context.obj({ Type: 'ExtGState', ...graphicsState });
+    const dict = page.pdfPage.doc.context.obj({ Type: 'ExtGState', ...params });
     page.extGStates[key] = (page.pdfPage as any).node.newExtGState('GS', dict);
   }
   return page.extGStates[key];

--- a/src/render-graphics.ts
+++ b/src/render-graphics.ts
@@ -25,7 +25,7 @@ import {
 
 import { Pos } from './box.js';
 import { LineCap, LineJoin } from './content.js';
-import { getPageGraphicsState, Page } from './page.js';
+import { getExtGraphicsState, Page } from './page.js';
 import {
   CircleObject,
   GraphicsObject,
@@ -106,9 +106,9 @@ function pathOperations(points: { x: number; y: number }[]): PDFOperator[] {
   return points.reduce((a: PDFOperator[], p) => [...a, (a.length ? lineTo : moveTo)(p.x, p.y)], []);
 }
 
-function drawPath(hasFillColor: boolean, haslineColor: boolean) {
-  if (hasFillColor && haslineColor) return fillAndStroke();
-  if (haslineColor) return stroke();
+function drawPath(hasFillColor: boolean, hasLineColor: boolean) {
+  if (hasFillColor && hasLineColor) return fillAndStroke();
+  if (hasLineColor) return stroke();
   return fill(); // fall back to a black shape
 }
 
@@ -127,9 +127,9 @@ const lineJoinTr = {
 const trLineJoin = (lineJoin: LineJoin) => lineJoinTr[lineJoin];
 
 function setStyleAttrs(shape: Shape, page: Page): PDFOperator[] {
-  const graphicsState = getGraphicsState(shape, page);
+  const extGraphicsState = getExtGraphicsStateForShape(page, shape);
   return [
-    graphicsState && setGraphicsState(graphicsState),
+    extGraphicsState && setGraphicsState(extGraphicsState),
     'fillColor' in shape && setFillingColor(shape.fillColor as any),
     'lineColor' in shape && setStrokingColor(shape.lineColor as any),
     'lineWidth' in shape && setLineWidth(shape.lineWidth as any),
@@ -143,13 +143,13 @@ function tr(pos: Pos, page: Page): Pos {
   return { x: pos.x, y: page.size.height - pos.y };
 }
 
-function getGraphicsState(shape: Shape, page: Page): PDFName | undefined {
+function getExtGraphicsStateForShape(page: Page, shape: Shape): PDFName | undefined {
   const { lineOpacity, fillOpacity } = shape as { lineOpacity: number; fillOpacity: number };
   if (lineOpacity != null || fillOpacity != null) {
-    const graphicsState = {
+    const graphicsParams = {
       CA: lineOpacity ?? 1,
       ca: fillOpacity ?? 1,
     };
-    return getPageGraphicsState(page, graphicsState);
+    return getExtGraphicsState(page, graphicsParams);
   }
 }

--- a/test/page.test.ts
+++ b/test/page.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from '@jest/globals';
 import { PDFFont, PDFPage } from 'pdf-lib';
 
-import { getPageFont, getPageGraphicsState, Page } from '../src/page.js';
+import { getExtGraphicsState, getPageFont, Page } from '../src/page.js';
 import { fakePdfFont, fakePdfPage } from './test-utils.js';
 
 describe('page', () => {
@@ -37,18 +37,18 @@ describe('page', () => {
     });
   });
 
-  describe('getPageGraphicsState', () => {
+  describe('getExtGraphicsState', () => {
     it('returns same graphics state for same input', () => {
-      const name1 = getPageGraphicsState(page, { ca: 0.1, CA: 0.2 });
-      const name2 = getPageGraphicsState(page, { ca: 0.1, CA: 0.2 });
+      const name1 = getExtGraphicsState(page, { ca: 0.1, CA: 0.2 });
+      const name2 = getExtGraphicsState(page, { ca: 0.1, CA: 0.2 });
 
       expect(name1.toString()).toBe('/GS-1');
       expect(name2).toEqual(name2);
     });
 
     it('returns different graphics states for different inputs', () => {
-      const name1 = getPageGraphicsState(page, { ca: 0.1, CA: 0.2 });
-      const name2 = getPageGraphicsState(page, { ca: 0.2, CA: 0.1 });
+      const name1 = getExtGraphicsState(page, { ca: 0.1, CA: 0.2 });
+      const name2 = getExtGraphicsState(page, { ca: 0.2, CA: 0.1 });
 
       expect(name1.toString()).toBe('/GS-1');
       expect(name2).not.toEqual(name1);


### PR DESCRIPTION
This commit adjusts the name of the function `getPageGraphicsState` that is related to *external graphics states* (`ExtGState` ) to `getExtGraphicsState` to better convey its purpose.