### PR TITLE
✨ Add support for letter spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
-## [0.4.1] - Unreleased
+## [0.4.2] - 2023-04-16
+
+### Added
+
+* Text attribute `letterSpacing`.
+
+## [0.4.1] - 2023-04-15 (not available)
+
+Note: This npm package `pdfmkr@0.4.1` had to be unpublished because of
+an error in the built package. Do to npm's policy, the version number
+cannot be reused.
 
 ### Fixed
 

--- a/examples/sample.js
+++ b/examples/sample.js
@@ -58,7 +58,7 @@ export default {
       text: [
         'Ut enim ',
         { text: 'ad minim veniam,', italic: true },
-        { text: ' quis nostrud', fontSize: 28 },
+        { text: ' quis nostrud', fontSize: 24, letterSpacing: 2.5 },
         ' exercitation ullamco laboris nisi ',
         {
           text: ['ut aliquip ', { text: 'ex ea commodo', italic: true }],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pdfmkr",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pdfmkr",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "@pdf-lib/fontkit": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdfmkr",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Generate PDF documents and from JavaScript objects",
   "license": "MIT",
   "repository": {

--- a/src/content.ts
+++ b/src/content.ts
@@ -419,6 +419,11 @@ export type TextAttrs = {
    * This setting does not affect the line height.
    */
   rise?: number;
+  /**
+   * The character spacing in pt. Positive values increase the space between characters, negative
+   * values decrease it.
+   */
+  letterSpacing?: number;
 };
 
 /**

--- a/src/layout-text.ts
+++ b/src/layout-text.ts
@@ -67,8 +67,9 @@ function layoutTextRow(segments: TextSegment[], box: Box, textAlign?: Alignment)
   const links: LinkObject[] = [];
   const segmentObjects: TextSegmentObject[] = [];
   flattenTextSegments(lineSegments).forEach((seg) => {
-    const { text, width, height, lineHeight, font, fontSize, link, color, rise } = seg;
-    segmentObjects.push({ text, font, fontSize, color, rise });
+    const { text, width, height, lineHeight, font, fontSize, link, color, rise, letterSpacing } =
+      seg;
+    segmentObjects.push({ text, font, fontSize, color, rise, letterSpacing });
     const offset = (height * lineHeight - height) / 2;
     if (link) {
       const linkPos = { x: box.x + pos.x, y: box.y - pos.y + offset };

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -52,6 +52,7 @@ export type TextSegmentObject = {
   fontSize: number;
   color?: Color;
   rise?: number;
+  letterSpacing?: number;
 };
 
 export type LinkObject = {

--- a/src/page.ts
+++ b/src/page.ts
@@ -3,7 +3,13 @@ import { Color, PDFFont, PDFImage, PDFName, PDFPage } from 'pdf-lib';
 import { Size } from './box.js';
 import { Frame } from './layout.js';
 
-export type TextState = { color?: Color; font?: string; size?: number; rise?: number };
+export type TextState = {
+  color?: Color;
+  font?: string;
+  size?: number;
+  rise?: number;
+  charSpace?: number;
+};
 
 export type Page = {
   size: Size;

--- a/src/read-block.ts
+++ b/src/read-block.ts
@@ -52,6 +52,7 @@ export type TextAttrs = {
   color?: Color;
   link?: string;
   rise?: number;
+  letterSpacing?: number;
 };
 
 type BlockAttrs = {
@@ -164,6 +165,7 @@ export function readTextAttrs(input: Obj): TextAttrs {
     color: optional(parseColor),
     link: optional(types.string()),
     rise: optional(types.number()),
+    letterSpacing: optional(types.number()),
   });
 }
 

--- a/src/render-text.ts
+++ b/src/render-text.ts
@@ -6,6 +6,7 @@ import {
   PDFName,
   PDFOperator,
   rgb,
+  setCharacterSpacing,
   setFillingColor,
   setFontAndSize,
   setTextMatrix,
@@ -32,6 +33,7 @@ export function renderText(object: TextObject, page: Page, base: Pos) {
         setTextColorOp(state, seg.color),
         setTextFontAndSizeOp(state, fontKey, seg.fontSize),
         setTextRiseOp(state, seg.rise),
+        setLetterSpacingOp(state, seg.letterSpacing),
         showText(encodedText),
       ].filter(Boolean) as PDFOperator[];
       contentStream.push(...operators);
@@ -64,6 +66,13 @@ function setTextRiseOp(state: TextState, rise?: number): PDFOperator | undefined
   if ((state.rise ?? 0) !== (rise ?? 0)) {
     state.rise = rise;
     return setTextRise(rise ?? 0);
+  }
+}
+
+function setLetterSpacingOp(state: TextState, charSpace?: number): PDFOperator | undefined {
+  if ((state.charSpace ?? 0) !== (charSpace ?? 0)) {
+    state.charSpace = charSpace;
+    return setCharacterSpacing(charSpace ?? 0);
   }
 }
 

--- a/src/text.ts
+++ b/src/text.ts
@@ -17,19 +17,27 @@ export type TextSegment = {
   color?: Color;
   link?: string;
   rise?: number;
+  letterSpacing?: number;
 };
 
 export function extractTextSegments(textSpans: TextSpan[], fonts: Font[]): TextSegment[] {
   return textSpans.flatMap((span) => {
     const { text, attrs } = span;
-    const { fontSize = defaultFontSize, lineHeight = defaultLineHeight, color, link, rise } = attrs;
+    const {
+      fontSize = defaultFontSize,
+      lineHeight = defaultLineHeight,
+      color,
+      link,
+      rise,
+      letterSpacing,
+    } = attrs;
     const font = selectFont(fonts, attrs);
     const height = font.heightAtSize(fontSize);
     return splitChunks(text).map(
       (text) =>
         ({
           text,
-          width: font.widthOfTextAtSize(text, fontSize),
+          width: font.widthOfTextAtSize(text, fontSize) + text.length * (letterSpacing ?? 0),
           height,
           lineHeight,
           font,
@@ -37,6 +45,7 @@ export function extractTextSegments(textSpans: TextSpan[], fonts: Font[]): TextS
           color,
           link,
           rise,
+          letterSpacing,
         } as TextSegment)
     );
   });
@@ -146,7 +155,8 @@ export function flattenTextSegments(segments: TextSegment[]): TextSegment[] {
       segment.lineHeight === prev?.lineHeight &&
       segment.color === prev?.color &&
       segment.link === prev?.link &&
-      segment.rise === prev?.rise
+      segment.rise === prev?.rise &&
+      segment.letterSpacing === prev?.letterSpacing
     ) {
       prev.text += segment.text;
       prev.width += segment.width;

--- a/test/layout-text.test.ts
+++ b/test/layout-text.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from '@jest/globals';
+import { rgb } from 'pdf-lib';
 
 import { Box } from '../src/box.js';
 import { Document } from '../src/document.js';
@@ -148,6 +149,33 @@ describe('layout', () => {
       expect(frame.objects).toEqual([
         { type: 'text', rows: [objectContaining({ x: 20, y: 30 })] },
         { type: 'link', x: 20, y: 30 + 1, width: 70, height: 10, url: 'test-link' },
+      ]);
+    });
+
+    it('includes extra text attrs in segments', () => {
+      const block = {
+        text: [
+          span('foo', {
+            fontSize: 10,
+            lineHeight: 1.2,
+            color: rgb(0, 0.5, 1),
+            rise: 3,
+            letterSpacing: 5,
+          }),
+        ],
+      };
+
+      const frame = layoutTextContent(block, box, doc);
+
+      expect((frame.objects?.[0] as any).rows[0].segments).toEqual([
+        {
+          font: doc.fonts[0].pdfFont,
+          fontSize: 10,
+          text: 'foo',
+          color: { type: 'RGB', blue: 1, green: 0.5, red: 0 },
+          rise: 3,
+          letterSpacing: 5,
+        },
       ]);
     });
   });

--- a/test/read-block.test.ts
+++ b/test/read-block.test.ts
@@ -120,6 +120,21 @@ describe('read-block', () => {
       });
     });
 
+    it('includes text attributes', () => {
+      const input = {
+        text: ['foo', 'bar'],
+        rise: 3,
+        letterSpacing: 5,
+      };
+
+      const result = readTextBlock(input);
+
+      expect(result.text).toEqual([
+        { text: 'foo', attrs: { rise: 3, letterSpacing: 5 } },
+        { text: 'bar', attrs: { rise: 3, letterSpacing: 5 } },
+      ]);
+    });
+
     it('includes default attrs in text', () => {
       const input = { text: 'foo' };
       const defaultAttrs = { fontSize: 14, lineHeight: 1.5 };

--- a/test/render-text.test.ts
+++ b/test/render-text.test.ts
@@ -39,12 +39,13 @@ describe('render-text', () => {
     });
 
     it('renders text rise', () => {
-      const seg1 = { text: 'foo', font, fontSize: 10 };
-      const seg2 = { text: 'bar', font, fontSize: 10, rise: 3 };
-      const seg3 = { text: 'baz', font, fontSize: 10 };
+      const s1 = { text: 'aaa', font, fontSize: 10 };
+      const s2 = { text: 'bbb', font, fontSize: 10, rise: 3 };
+      const s3 = { text: 'ccc', font, fontSize: 10, rise: 3 };
+      const s4 = { text: 'ddd', font, fontSize: 10 };
       const obj: TextObject = {
         type: 'text',
-        rows: [{ segments: [seg1, seg2, seg3], x: 1, y: 2, width: 60, height: 12, baseline: 8 }],
+        rows: [{ segments: [s1, s2, s3, s4], x: 1, y: 2, width: 60, height: 12, baseline: 8 }],
       };
 
       renderText(obj, page, pos);
@@ -54,50 +55,82 @@ describe('render-text', () => {
         '1 0 0 1 11 770 Tm',
         '0 0 0 rg',
         '/fontA-1 10 Tf',
-        'foo Tj',
-        '3 Ts',
-        'bar Tj',
-        '0 Ts',
-        'baz Tj',
+        'aaa Tj',
+        '3 Ts', // set text rise
+        'bbb Tj',
+        'ccc Tj',
+        '0 Ts', // reset text rise
+        'ddd Tj',
         'ET',
       ]);
     });
 
-    it('maintains text state throughout page', () => {
-      const obj1: TextObject = {
+    it('renders letter spacing', () => {
+      const seg1 = { text: 'aaa', font, fontSize: 10 };
+      const seg2 = { text: 'bbb', font, fontSize: 10, letterSpacing: 3 };
+      const seg3 = { text: 'ccc', font, fontSize: 10, letterSpacing: 3 };
+      const seg4 = { text: 'ddd', font, fontSize: 10 };
+      const obj: TextObject = {
         type: 'text',
         rows: [
-          {
-            segments: [{ text: 'foo', font, fontSize: 10, rise: 3 }],
-            ...{ x: 1, y: 2, width: 60, height: 12, baseline: 8 },
-          },
-        ],
-      };
-      const obj2: TextObject = {
-        type: 'text',
-        rows: [
-          {
-            segments: [{ text: 'bar', font, fontSize: 10 }],
-            ...{ x: 3, y: 4, width: 60, height: 12, baseline: 8 },
-          },
+          { segments: [seg1, seg2, seg3, seg4], x: 1, y: 2, width: 60, height: 12, baseline: 8 },
         ],
       };
 
-      renderText(obj1, page, pos);
-      renderText(obj2, page, pos);
+      renderText(obj, page, pos);
 
       expect(getContentStream(page)).toEqual([
         'BT',
         '1 0 0 1 11 770 Tm',
         '0 0 0 rg',
         '/fontA-1 10 Tf',
-        '3 Ts',
-        'foo Tj',
+        'aaa Tj',
+        '3 Tc', // set letter spacing
+        'bbb Tj',
+        'ccc Tj',
+        '0 Tc', // reset letter spacing
+        'ddd Tj',
+        'ET',
+      ]);
+    });
+
+    it('maintains text state throughout page', () => {
+      const s1 = { text: 'aaa', font, fontSize: 10, rise: 3 };
+      const s2 = { text: 'bbb', font, fontSize: 10, rise: 3 };
+      const s3 = { text: 'ccc', font, fontSize: 10 };
+      const obj1: TextObject = {
+        type: 'text',
+        rows: [{ segments: [s1], x: 1, y: 2, width: 60, height: 12, baseline: 8 }],
+      };
+      const obj2: TextObject = {
+        type: 'text',
+        rows: [{ segments: [s2], x: 1, y: 2, width: 60, height: 12, baseline: 8 }],
+      };
+      const obj3: TextObject = {
+        type: 'text',
+        rows: [{ segments: [s3], x: 3, y: 4, width: 60, height: 12, baseline: 8 }],
+      };
+
+      renderText(obj1, page, pos);
+      renderText(obj2, page, pos);
+      renderText(obj3, page, pos);
+
+      expect(getContentStream(page)).toEqual([
+        'BT',
+        '1 0 0 1 11 770 Tm',
+        '0 0 0 rg',
+        '/fontA-1 10 Tf',
+        '3 Ts', // set text rise
+        'aaa Tj',
+        'ET',
+        'BT',
+        '1 0 0 1 11 770 Tm',
+        'bbb Tj',
         'ET',
         'BT',
         '1 0 0 1 13 768 Tm',
         '0 Ts', // reset text rise
-        'bar Tj',
+        'ccc Tj',
         'ET',
       ]);
     });

--- a/test/text.test.ts
+++ b/test/text.test.ts
@@ -41,17 +41,25 @@ describe('text', () => {
     });
 
     it('respects global text attrs', () => {
-      const attrs = { fontSize: 10, lineHeight: 1.5, color: rgb(1, 0, 0) };
+      const attrs = {
+        fontSize: 10,
+        lineHeight: 1.5,
+        color: rgb(1, 0, 0),
+        rise: 3,
+        letterSpacing: 5,
+      };
 
       const segments = extractTextSegments([{ text: 'foo', attrs }], fonts);
 
       expect(segments).toEqual([
         objectContaining({
-          width: 3 * 10,
+          width: 3 * (10 + 5), // 3 chars * 10pt + 5pt letterSpacing
           height: 10,
           fontSize: 10,
           lineHeight: 1.5,
           color: rgb(1, 0, 0),
+          rise: 3,
+          letterSpacing: 5,
         }),
       ]);
     });


### PR DESCRIPTION
This commit adds a new text attribute `letterSpacing`. Its behavior is similar to the CSS property `letter-spacing`. This attribute accepts a number, which is the extra character spacing in pt. The default letter spacing is 0. Positive values increase the spacing between characters, while negative values decrease it.