### PR TITLE
✨ Support drawing SVG paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,12 @@
 ### Added
 
 * Text attribute `letterSpacing`.
+* Support for SVG paths in `graphics` using `Path` elements.
 
 ## [0.4.1] - 2023-04-15 (not available)
 
 Note: This npm package `pdfmkr@0.4.1` had to be unpublished because of
-an error in the built package. Do to npm's policy, the version number
-cannot be reused.
+a build error. Do to npm's policy, the version number cannot be reused.
 
 ### Fixed
 
@@ -104,3 +104,4 @@ First public version.
 [0.3.2]: https://github.com/eclipsesource/pdf-maker/releases/tag/v0.3.2
 [0.3.3]: https://github.com/eclipsesource/pdf-maker/releases/tag/v0.3.3
 [0.4.0]: https://github.com/eclipsesource/pdf-maker/releases/tag/v0.4.0
+[0.4.2]: https://github.com/eclipsesource/pdf-maker/releases/tag/v0.4.0

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Ralf Sternberg, EclipseSource
+Copyright (c) 2023 Ralf Sternberg, EclipseSource
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/examples/sample.js
+++ b/examples/sample.js
@@ -129,6 +129,12 @@ export default {
               lineWidth: 2,
             },
             {
+              type: 'path',
+              d: 'M 10,40 c 20,0 20,-30 40,-30 s 20,30 40,30 s 20,-30 40,-30 s 20,30 40,30',
+              lineWidth: 1,
+              lineColor: 'red',
+            },
+            {
               type: 'polyline',
               points: [
                 { x: 50, y: 76 },

--- a/src/arcs.ts
+++ b/src/arcs.ts
@@ -1,0 +1,106 @@
+// The code in this file was copied from pdf-lib Copyright (c) 2019 Andrew Dillon
+// https://github.com/Hopding/pdf-lib/blob/v1.17.1/src/api/svgPath.ts
+// Originated from pdfkit Copyright (c) 2014 Devon Govett
+// https://github.com/foliojs/pdfkit/blob/1e62e6ffe24b378eb890df507a47610f4c4a7b24/lib/path.js
+// MIT LICENSE
+// Updated for pdf-lib & TypeScript by Jeremy Messenger
+// Minor adjustments for use in pdf-maker by Ralf Sternberg
+
+type Bezier = [number, number, number, number, number, number];
+type Segment = [number, number, number, number, number, number, number, number];
+
+// from Inkscape svgtopdf, thanks!
+// copied from pdf-lib, parameters reordered.
+export const arcToSegments = (
+  ox: number,
+  oy: number,
+  rx: number,
+  ry: number,
+  rotateX: number,
+  large: number,
+  sweep: number,
+  x: number,
+  y: number
+) => {
+  const th = rotateX * (Math.PI / 180);
+  const sinTh = Math.sin(th);
+  const cosTh = Math.cos(th);
+  rx = Math.abs(rx);
+  ry = Math.abs(ry);
+  const px = cosTh * (ox - x) * 0.5 + sinTh * (oy - y) * 0.5;
+  const py = cosTh * (oy - y) * 0.5 - sinTh * (ox - x) * 0.5;
+  let pl = (px * px) / (rx * rx) + (py * py) / (ry * ry);
+  if (pl > 1) {
+    pl = Math.sqrt(pl);
+    rx *= pl;
+    ry *= pl;
+  }
+
+  const a00 = cosTh / rx;
+  const a01 = sinTh / rx;
+  const a10 = -sinTh / ry;
+  const a11 = cosTh / ry;
+  const x0 = a00 * ox + a01 * oy;
+  const y0 = a10 * ox + a11 * oy;
+  const x1 = a00 * x + a01 * y;
+  const y1 = a10 * x + a11 * y;
+
+  const d = (x1 - x0) * (x1 - x0) + (y1 - y0) * (y1 - y0);
+  let sfactorSq = 1 / d - 0.25;
+  if (sfactorSq < 0) {
+    sfactorSq = 0;
+  }
+  let sfactor = Math.sqrt(sfactorSq);
+  if (sweep === large) {
+    sfactor = -sfactor;
+  }
+
+  const xc = 0.5 * (x0 + x1) - sfactor * (y1 - y0);
+  const yc = 0.5 * (y0 + y1) + sfactor * (x1 - x0);
+
+  const th0 = Math.atan2(y0 - yc, x0 - xc);
+  const th1 = Math.atan2(y1 - yc, x1 - xc);
+
+  let thArc = th1 - th0;
+  if (thArc < 0 && sweep === 1) {
+    thArc += 2 * Math.PI;
+  } else if (thArc > 0 && sweep === 0) {
+    thArc -= 2 * Math.PI;
+  }
+
+  const segments = Math.ceil(Math.abs(thArc / (Math.PI * 0.5 + 0.001)));
+  const result: Segment[] = [];
+
+  for (let i = 0; i < segments; i++) {
+    const th2 = th0 + (i * thArc) / segments;
+    const th3 = th0 + ((i + 1) * thArc) / segments;
+    result[i] = [xc, yc, th2, th3, rx, ry, sinTh, cosTh];
+  }
+
+  return result;
+};
+
+export function segmentToBezier([cx1, cy1, th0, th1, rx, ry, sinTh, cosTh]: number[]): Bezier {
+  const a00 = cosTh * rx;
+  const a01 = -sinTh * ry;
+  const a10 = sinTh * rx;
+  const a11 = cosTh * ry;
+
+  const thHalf = 0.5 * (th1 - th0);
+  const t = ((8 / 3) * Math.sin(thHalf * 0.5) * Math.sin(thHalf * 0.5)) / Math.sin(thHalf);
+  const x1 = cx1 + Math.cos(th0) - t * Math.sin(th0);
+  const y1 = cy1 + Math.sin(th0) + t * Math.cos(th0);
+  const x3 = cx1 + Math.cos(th1);
+  const y3 = cy1 + Math.sin(th1);
+  const x2 = x3 + t * Math.sin(th1);
+  const y2 = y3 - t * Math.cos(th1);
+
+  return [
+    a00 * x1 + a01 * y1,
+    a10 * x1 + a11 * y1,
+    a00 * x2 + a01 * y2,
+    a10 * x2 + a11 * y2,
+    a00 * x3 + a01 * y3,
+    a10 * x3 + a11 * y3,
+  ];
+}

--- a/src/content.ts
+++ b/src/content.ts
@@ -280,37 +280,100 @@ export type BlockInfo = {
   readonly padding: { left: number; right: number; top: number; bottom: number };
 };
 
-export type Shape = Rect | Circle | Line | Polyline;
+export type Shape = Rect | Circle | Line | Polyline | Path;
 
+/**
+ * A rectangle.
+ */
 export type Rect = {
   type: 'rect';
+  /**
+   * The x coordinate of the top left corner of the rectangle.
+   */
   x: number;
+  /**
+   * The y coordinate of the top left corner of the rectangle.
+   */
   y: number;
+  /**
+   * The width of the rectangle.
+   */
   width: number;
+  /**
+   * The height of the rectangle.
+   */
   height: number;
 } & Omit<LineAttrs, 'lineCap'> &
   FillAttrs;
 
+/**
+ * A circle.
+ */
 export type Circle = {
   type: 'circle';
+  /**
+   * The x coordinate of the center of the circle.
+   */
   cx: number;
+  /**
+   * The y coordinate of the center of the circle.
+   */
   cy: number;
+  /**
+   * The radius of the circle.
+   */
   r: number;
 } & Omit<LineAttrs, 'lineCap'> &
   FillAttrs;
 
+/**
+ * A straight line.
+ */
 export type Line = {
   type: 'line';
+  /**
+   * The x coordinate of the start point of the line.
+   */
   x1: number;
+  /**
+   * The y coordinate of the start point of the line.
+   */
   y1: number;
+  /**
+   * The x coordinate of the end point of the line.
+   */
   x2: number;
+  /**
+   * The y coordinate of the end point of the line.
+   */
   y2: number;
 } & Omit<LineAttrs, 'lineJoin'>;
 
+/**
+ * A polyline, i.e. a line consisting of multiple segments.
+ */
 export type Polyline = {
   type: 'polyline';
+  /**
+   * The points of the polyline, each point as an object with `x` and `y` coordinates.
+   */
   points: { x: number; y: number }[];
+  /**
+   * Whether to close the path by drawing a line from the last point to the first point.
+   */
   closePath?: boolean;
+} & LineAttrs &
+  FillAttrs;
+
+/**
+ * An SVG path element.
+ */
+export type Path = {
+  type: 'path';
+  /**
+   * An SVG path. See https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/d for details.
+   */
+  d: string;
 } & LineAttrs &
   FillAttrs;
 

--- a/src/svg-paths.ts
+++ b/src/svg-paths.ts
@@ -1,0 +1,227 @@
+import {
+  appendBezierCurve,
+  appendQuadraticCurve,
+  closePath,
+  lineTo,
+  moveTo,
+  PDFOperator,
+} from 'pdf-lib';
+
+import { arcToSegments, segmentToBezier } from './arcs.js';
+
+const svgOpsParams = {
+  M: 2,
+  m: 2,
+  L: 2,
+  l: 2,
+  H: 1,
+  h: 1,
+  V: 1,
+  v: 1,
+  C: 6,
+  c: 6,
+  S: 4,
+  s: 4,
+  Q: 4,
+  q: 4,
+  T: 2,
+  t: 2,
+  A: 7,
+  a: 7,
+  Z: 0,
+  z: 0,
+};
+
+type Op = keyof typeof svgOpsParams;
+
+export type PathCommand = {
+  op: Op;
+  params?: number[];
+};
+
+type Token = { start: number; op?: Op; value?: number };
+
+export function tokenizeSvgPath(path: string): Token[] {
+  const tokens: Token[] = [];
+  let pos = 0;
+  while (pos < path.length) {
+    const start = pos;
+    const c = path[pos++];
+    if (c === ',' || c === ' ' || c === '\t' || c === '\n' || c === '\r') {
+      // ignore commas and whitespace
+    } else if (c in svgOpsParams) {
+      tokens.push({ start, op: c as Op });
+    } else if (c === '-' || c === '+' || c === '.' || (c >= '0' && c <= '9')) {
+      let s = c;
+      while (
+        pos < path.length &&
+        ((path[pos] >= '0' && path[pos] <= '9') || (path[pos] === '.' && !s.includes('.')))
+      ) {
+        s += path[pos++];
+      }
+      const value = parseFloat(s);
+      tokens.push({ start, value });
+    } else {
+      throw new Error(`Unexpected character: '${c}' at position ${pos - 1}`);
+    }
+  }
+  return tokens;
+}
+
+export function parseSvgPath(path: string) {
+  const tokens = tokenizeSvgPath(path);
+  const commands: PathCommand[] = [];
+
+  let pos = 0;
+
+  const hasParam = () => {
+    return tokens[pos]?.value !== undefined;
+  };
+
+  const readParam = () => {
+    if (!hasParam())
+      throw new Error(
+        'Expected parameter at ' + (tokens[pos] ? 'position ' + tokens[pos]?.start : 'end')
+      );
+    return tokens[pos++].value as number;
+  };
+
+  const readParams = (count: number) => {
+    if (!count) return undefined;
+    return Array.from(new Array(count)).map(() => readParam());
+  };
+
+  const readCommand = () => {
+    const token = tokens[pos++];
+    if (!token?.op) return;
+    const op = token.op;
+    const params = svgOpsParams[op as Op];
+    commands.push({ op, params: readParams(params) });
+    if (op !== 'Z' && op !== 'z') {
+      while (hasParam()) {
+        const nextOp = op === 'M' ? 'L' : op === 'm' ? 'l' : op;
+        commands.push({ op: nextOp, params: readParams(params) });
+      }
+    }
+    return true;
+  };
+
+  while (readCommand());
+
+  return commands;
+}
+
+export function svgPathToPdfOps(commands: PathCommand[]): PDFOperator[] {
+  let cx = 0;
+  let cy = 0;
+  let px = 0;
+  let py = 0;
+  let lastCurve: 'b' | 'q' | undefined = undefined;
+
+  const opMoveTo = (x: number, y: number) => {
+    cx = x;
+    cy = y;
+    lastCurve = undefined;
+    return [moveTo(cx, cy)];
+  };
+  const opLineTo = (x: number, y: number) => {
+    cx = x;
+    cy = y;
+    lastCurve = undefined;
+    return [lineTo(cx, cy)];
+  };
+  const opBezierCurve = (x1: number, y1: number, x2: number, y2: number, x: number, y: number) => {
+    cx = x;
+    cy = y;
+    px = x2;
+    py = y2;
+    lastCurve = 'b';
+    return [appendBezierCurve(x1, y1, x2, y2, cx, cy)];
+  };
+  const opQuadraticCurve = (x1: number, y1: number, x: number, y: number) => {
+    cx = x;
+    cy = y;
+    px = x1;
+    py = y1;
+    lastCurve = 'q';
+    return [appendQuadraticCurve(x1, y1, cx, cy)];
+  };
+  const opArc = (rx: number, ry: number, a: number, l: number, s: number, x: number, y: number) => {
+    const segments = arcToSegments(cx, cy, rx, ry, a, l, s, x, y);
+    cx = x;
+    cy = y;
+    lastCurve = undefined;
+    return segments.flatMap((seg) => appendBezierCurve(...segmentToBezier(seg)));
+  };
+  const opClosePath = () => {
+    lastCurve = undefined;
+    return [closePath()];
+  };
+  const mirrorCx = (type: 'b' | 'q') => (lastCurve === type ? 2 * cx - px : cx);
+  const mirrorCy = (type: 'b' | 'q') => (lastCurve === type ? 2 * cy - py : cy);
+
+  const ops: Record<Op, (params?: number[]) => PDFOperator[]> = {
+    M: ([x, y]: number[]) => {
+      return opMoveTo(x, y);
+    },
+    m: ([dx, dy]: number[]) => {
+      return opMoveTo(cx + dx, cy + dy);
+    },
+    L: ([x, y]: number[]) => {
+      return opLineTo(x, y);
+    },
+    l: ([dx, dy]: number[]) => {
+      return opLineTo(cx + dx, cy + dy);
+    },
+    H: ([x]: number[]) => {
+      return opLineTo(x, cy);
+    },
+    h: ([dx]: number[]) => {
+      return opLineTo(cx + dx, cy);
+    },
+    V: ([y]: number[]) => {
+      return opLineTo(cx, y);
+    },
+    v: ([dy]: number[]) => {
+      return opLineTo(cx, cy + dy);
+    },
+    C: ([x1, y1, x2, y2, x, y]: number[]) => {
+      return opBezierCurve(x1, y1, x2, y2, x, y);
+    },
+    c: ([dx1, dy1, dx2, dy2, dx, dy]: number[]) => {
+      return opBezierCurve(cx + dx1, cy + dy1, cx + dx2, cy + dy2, cx + dx, cy + dy);
+    },
+    S: ([x2, y2, x, y]: number[]) => {
+      return opBezierCurve(mirrorCx('b'), mirrorCy('b'), x2, y2, x, y);
+    },
+    s: ([dx2, dy2, dx, dy]: number[]) => {
+      return opBezierCurve(mirrorCx('b'), mirrorCy('b'), cx + dx2, cy + dy2, cx + dx, cy + dy);
+    },
+    Q: ([x1, y1, x, y]: number[]) => {
+      return opQuadraticCurve(x1, y1, x, y);
+    },
+    q: ([dx1, dy1, dx, dy]: number[]) => {
+      return opQuadraticCurve(cx + dx1, cy + dy1, cx + dx, cy + dy);
+    },
+    T: ([x, y]: number[]) => {
+      return opQuadraticCurve(mirrorCx('q'), mirrorCy('q'), x, y);
+    },
+    t: ([dx, dy]: number[]) => {
+      return opQuadraticCurve(mirrorCx('q'), mirrorCy('q'), cx + dx, cy + dy);
+    },
+    A: ([rx, ry, angle, largeArc, sweep, x, y]: number[]) => {
+      return opArc(rx, ry, angle, largeArc, sweep, x, y);
+    },
+    a: ([rx, ry, angle, largeArc, sweep, dx, dy]: number[]) => {
+      return opArc(rx, ry, angle, largeArc, sweep, cx + dx, cy + dy);
+    },
+    Z: () => {
+      return opClosePath();
+    },
+    z: () => {
+      return opClosePath();
+    },
+  } as Record<Op, (params?: number[]) => PDFOperator[]>;
+
+  return commands.flatMap(({ op, params }) => ops[op](params));
+}

--- a/test/read-graphics.test.ts
+++ b/test/read-graphics.test.ts
@@ -15,7 +15,7 @@ describe('read-graphics', () => {
       const fn = () => readShape({ type: 'foo' });
 
       expect(fn).toThrowError(
-        `Invalid value for "type": Expected one of ('rect', 'circle', 'line', 'polyline'), got: 'foo'`
+        `Invalid value for "type": Expected one of ('rect', 'circle', 'line', 'polyline', 'path'), got: 'foo'`
       );
     });
 
@@ -134,6 +134,31 @@ describe('read-graphics', () => {
       const fn = () => readShape({ type: 'polyline', points: [{ x: 1, y: 'a' }] });
 
       expect(fn).toThrowError(`Invalid value for "points/0/y": Expected number, got: 'a'`);
+    });
+
+    it('parses path object', () => {
+      const path = {
+        ...{ type: 'path', d: 'M 1 2 c 3 4 5 6 7 8 s 9 10 11 12 z' },
+        lineWidth: 1.5,
+        lineColor: 'red',
+        fillColor: 'blue',
+        lineOpacity: 0.5,
+        fillOpacity: 0.3,
+      };
+
+      expect(readShape(path)).toEqual({
+        ...path,
+        commands: [
+          { op: 'M', params: [1, 2] },
+          { op: 'c', params: [3, 4, 5, 6, 7, 8] },
+          { op: 's', params: [9, 10, 11, 12] },
+          { op: 'z' },
+        ],
+        lineColor: rgb(1, 0, 0),
+        fillColor: rgb(0, 0, 1),
+        lineOpacity: 0.5,
+        fillOpacity: 0.3,
+      });
     });
 
     ['lineColor', 'fillColor'].forEach((name) => {

--- a/test/svg-paths.test.ts
+++ b/test/svg-paths.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { parseSvgPath, svgPathToPdfOps, tokenizeSvgPath } from '../src/svg-paths.js';
+
+describe('svg-paths', () => {
+  describe('tokenize', () => {
+    it('returns empty list of tokens', () => {
+      expect(tokenizeSvgPath('')).toEqual([]);
+      expect(tokenizeSvgPath(' ')).toEqual([]);
+      expect(tokenizeSvgPath(' , , \t  , \n , ')).toEqual([]);
+    });
+
+    it('returns commands and parameters', () => {
+      const tokens = tokenizeSvgPath('M 1 2 3');
+
+      expect(tokens).toEqual([
+        { start: 0, op: 'M' },
+        { start: 2, value: 1 },
+        { start: 4, value: 2 },
+        { start: 6, value: 3 },
+      ]);
+    });
+
+    it('handles surrounding whitespace', () => {
+      expect(tokenizeSvgPath(' M 1 2 ')).toEqual([
+        { start: 1, op: 'M' },
+        { start: 3, value: 1 },
+        { start: 5, value: 2 },
+      ]);
+      expect(tokenizeSvgPath(' , M \n 1 \t 2 ')).toEqual([
+        { start: 3, op: 'M' },
+        { start: 7, value: 1 },
+        { start: 11, value: 2 },
+      ]);
+    });
+
+    it('handles dense notation', () => {
+      const tokens = tokenizeSvgPath('M.1.2L-3+4');
+
+      expect(tokens).toEqual([
+        { start: 0, op: 'M' },
+        { start: 1, value: 0.1 },
+        { start: 3, value: 0.2 },
+        { start: 5, op: 'L' },
+        { start: 6, value: -3 },
+        { start: 8, value: 4 },
+      ]);
+    });
+
+    it('throws for invalid commands', () => {
+      expect(() => tokenizeSvgPath('M 1 x 2')).toThrowError(
+        "Unexpected character: 'x' at position 4"
+      );
+      expect(() => tokenizeSvgPath('M1?2')).toThrowError("Unexpected character: '?' at position 2");
+    });
+  });
+
+  describe('parseSvgPath', () => {
+    it('returns empty list of commands', () => {
+      expect(parseSvgPath('')).toEqual([]);
+      expect(parseSvgPath(' ')).toEqual([]);
+      expect(parseSvgPath(' , , \t  , \n , ')).toEqual([]);
+    });
+
+    it('returns commands for M', () => {
+      const commands = parseSvgPath('M 1 2 3 4 5 6');
+
+      expect(commands).toEqual([
+        { op: 'M', params: [1, 2] },
+        { op: 'L', params: [3, 4] },
+        { op: 'L', params: [5, 6] },
+      ]);
+    });
+
+    it('returns commands for m', () => {
+      const commands = parseSvgPath('m 1 2 3 4 5 6');
+
+      expect(commands).toEqual([
+        { op: 'm', params: [1, 2] },
+        { op: 'l', params: [3, 4] },
+        { op: 'l', params: [5, 6] },
+      ]);
+    });
+
+    it('returns commands for C', () => {
+      const commands = parseSvgPath('C 1 2 3 4 5 6 7 8 9 10 11 12');
+
+      expect(commands).toEqual([
+        { op: 'C', params: [1, 2, 3, 4, 5, 6] },
+        { op: 'C', params: [7, 8, 9, 10, 11, 12] },
+      ]);
+    });
+
+    it('returns commands for c', () => {
+      const commands = parseSvgPath('c 1 2 3 4 5 6 7 8 9 10 11 12');
+
+      expect(commands).toEqual([
+        { op: 'c', params: [1, 2, 3, 4, 5, 6] },
+        { op: 'c', params: [7, 8, 9, 10, 11, 12] },
+      ]);
+    });
+
+    it('returns commands for Z and z', () => {
+      expect(parseSvgPath('Z')).toEqual([{ op: 'Z' }]);
+      expect(parseSvgPath('z')).toEqual([{ op: 'z' }]);
+    });
+
+    it('returns commands for a sequence of ops', () => {
+      const commands = parseSvgPath('M 1 2 L 3 4 S 5 6 7 8 Z');
+
+      expect(commands).toEqual([
+        { op: 'M', params: [1, 2] },
+        { op: 'L', params: [3, 4] },
+        { op: 'S', params: [5, 6, 7, 8] },
+        { op: 'Z' },
+      ]);
+    });
+
+    it('throws for unexpected parameters', () => {
+      expect(() => parseSvgPath('M 1 2 3')).toThrowError('Expected parameter at end');
+      expect(() => parseSvgPath('M 1 2 3 L 4 5')).toThrowError('Expected parameter at position 8');
+    });
+  });
+
+  describe('svgPathToPdfOps', () => {
+    const pdfOps = (path: string) => svgPathToPdfOps(parseSvgPath(path)).map(String);
+
+    it('creates ops for M', () => {
+      expect(pdfOps('M 1 2')).toEqual(['1 2 m']);
+    });
+
+    it('creates ops for m', () => {
+      expect(pdfOps('m 1 2')).toEqual(['1 2 m']);
+      expect(pdfOps('M 1 2 m 3 4')).toEqual(['1 2 m', '4 6 m']);
+    });
+
+    it('creates ops for L', () => {
+      expect(pdfOps('L 1 2')).toEqual(['1 2 l']);
+    });
+
+    it('creates ops for l', () => {
+      expect(pdfOps('l 1 2')).toEqual(['1 2 l']);
+      expect(pdfOps('M 1 2 l 3 4')).toEqual(['1 2 m', '4 6 l']);
+    });
+
+    it('creates ops for H', () => {
+      expect(pdfOps('H 1')).toEqual(['1 0 l']);
+      expect(pdfOps('M 1 2 H 3')).toEqual(['1 2 m', '3 2 l']);
+    });
+
+    it('creates ops for h', () => {
+      expect(pdfOps('h 1')).toEqual(['1 0 l']);
+      expect(pdfOps('M 1 2 h 3')).toEqual(['1 2 m', '4 2 l']);
+    });
+
+    it('creates ops for V', () => {
+      expect(pdfOps('V 1')).toEqual(['0 1 l']);
+      expect(pdfOps('M 1 2 V 3')).toEqual(['1 2 m', '1 3 l']);
+    });
+
+    it('creates ops for v', () => {
+      expect(pdfOps('v 1')).toEqual(['0 1 l']);
+      expect(pdfOps('M 1 2 v 3')).toEqual(['1 2 m', '1 5 l']);
+    });
+
+    it('creates ops for C', () => {
+      expect(pdfOps('C 1 2 3 4 5 6')).toEqual(['1 2 3 4 5 6 c']);
+    });
+
+    it('creates ops for c', () => {
+      expect(pdfOps('c 1 2 3 4 5 6')).toEqual(['1 2 3 4 5 6 c']);
+      expect(pdfOps('M 1 2 c 3 4 5 6 7 8')).toEqual(['1 2 m', '4 6 6 8 8 10 c']);
+      expect(pdfOps('C 1 2 3 4 5 6 c 7 8 9 10 11 12')).toEqual([
+        '1 2 3 4 5 6 c',
+        '12 14 14 16 16 18 c',
+      ]);
+    });
+
+    it('creates ops for S', () => {
+      expect(pdfOps('S 1 2 3 4')).toEqual(['0 0 1 2 3 4 c']);
+      expect(pdfOps('M 1 2 S 3 4 5 6')).toEqual(['1 2 m', '1 2 3 4 5 6 c']);
+      expect(pdfOps('S 1 2 3 4 S 5 6 7 8')).toEqual(['0 0 1 2 3 4 c', '5 6 5 6 7 8 c']);
+    });
+
+    it('creates ops for s', () => {
+      expect(pdfOps('s 1 2 3 4')).toEqual(['0 0 1 2 3 4 c']);
+      expect(pdfOps('M 1 2 s 3 4 5 6')).toEqual(['1 2 m', '1 2 4 6 6 8 c']);
+      expect(pdfOps('S 1 2 3 4 s 5 6 7 8')).toEqual(['0 0 1 2 3 4 c', '5 6 8 10 10 12 c']);
+    });
+
+    it('creates ops for Q', () => {
+      expect(pdfOps('Q 1 2 3 4')).toEqual(['1 2 3 4 v']);
+    });
+
+    it('creates ops for q', () => {
+      expect(pdfOps('q 1 2 3 4')).toEqual(['1 2 3 4 v']);
+      expect(pdfOps('M 1 2 q 3 4 5 6')).toEqual(['1 2 m', '4 6 6 8 v']);
+      expect(pdfOps('Q 1 2 3 4 q 5 6 7 8')).toEqual(['1 2 3 4 v', '8 10 10 12 v']);
+    });
+
+    it('creates ops for T', () => {
+      expect(pdfOps('T 1 2')).toEqual(['0 0 1 2 v']);
+      expect(pdfOps('M 1 2 T 3 4')).toEqual(['1 2 m', '1 2 3 4 v']);
+      expect(pdfOps('T 1 2 T 3 4')).toEqual(['0 0 1 2 v', '2 4 3 4 v']);
+    });
+
+    it('creates ops for t', () => {
+      expect(pdfOps('t 1 2')).toEqual(['0 0 1 2 v']);
+      expect(pdfOps('M 1 2 t 3 4')).toEqual(['1 2 m', '1 2 4 6 v']);
+      expect(pdfOps('T 1 2 t 3 4')).toEqual(['0 0 1 2 v', '2 4 4 6 v']);
+    });
+
+    it('creates ops for A', () => {
+      expect(pdfOps('A 1 2 0 0 1 3 4').map((s) => s.replace(/\.\d+/g, ''))).toEqual([
+        '0 -1 1 -2 2 -1 c',
+        '3 0 3 2 3 4 c',
+      ]);
+    });
+
+    it('creates ops for a', () => {
+      expect(pdfOps('a 1 2 0 0 1 3 4').map((s) => s.replace(/\.\d+/g, ''))).toEqual([
+        '0 -1 1 -2 2 -1 c',
+        '3 0 3 2 3 4 c',
+      ]);
+      expect(pdfOps('M 1 2 a 3 4 0 0 1 5 6').map((s) => s.replace(/\.\d+/g, ''))).toEqual([
+        '1 2 m',
+        '2 0 4 0 5 1 c',
+        '7 3 7 6 6 8 c',
+      ]);
+    });
+
+    it('creates ops for Z', () => {
+      expect(pdfOps('Z')).toEqual(['h']);
+    });
+
+    it('creates ops for z', () => {
+      expect(pdfOps('z')).toEqual(['h']);
+    });
+  });
+});


### PR DESCRIPTION
This commit adds full support for SVG paths in `graphics`. To draw an SVG path, an element of type `path` accept an SVG path in a parameter `d`, similar to the SVG `<path>` element. Paths are expected in the syntax used by the `d` attribute of the SVG `<path>`. All path commands as described in [1] are supported.

[1] https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/d#path_commands