### PR TITLE
♻️ Introduce util function compact

### DIFF
--- a/src/guides.ts
+++ b/src/guides.ts
@@ -3,7 +3,8 @@ import { rgb } from 'pdf-lib';
 import { ZERO_EDGES } from './box.js';
 import { Frame, TextRowObject } from './layout.js';
 import { Block } from './read-block.js';
-import { CircleObject, GraphicsObject, LineObject, RectObject, Shape } from './read-graphics.js';
+import { CircleObject, GraphicsObject, LineObject, RectObject } from './read-graphics.js';
+import { compact } from './utils.js';
 
 export function createFrameGuides(
   frame: Frame,
@@ -17,18 +18,18 @@ export function createFrameGuides(
   const fill = { fillColor: rgb(0, 0, 0), fillOpacity: 0.25 };
   const mFill = { fillColor: rgb(0.9, 0.8, 0.3), fillOpacity: 0.15 };
   const pFill = { fillColor: rgb(0.2, 0.2, 0.7), fillOpacity: 0.15 };
-  const shapes = [
+  const shapes = compact([
     rect({ x: 0, y: 0, width: w, height: h, ...stroke }),
     // margin
-    mt && rect({ x: -ml, y: -mt, width: w + ml + mr, height: mt, ...mFill }),
-    ml && rect({ x: -ml, y: 0, width: ml, height: h, ...mFill }),
-    mr && rect({ x: w, y: 0, width: mr, height: h, ...mFill }),
-    mb && rect({ x: -ml, y: h, width: w + ml + mr, height: mb, ...mFill }),
+    !!mt && rect({ x: -ml, y: -mt, width: w + ml + mr, height: mt, ...mFill }),
+    !!ml && rect({ x: -ml, y: 0, width: ml, height: h, ...mFill }),
+    !!mr && rect({ x: w, y: 0, width: mr, height: h, ...mFill }),
+    !!mb && rect({ x: -ml, y: h, width: w + ml + mr, height: mb, ...mFill }),
     // padding
-    pt && rect({ x: 0, y: 0, width: w, height: pt, ...pFill }),
-    pl && rect({ x: 0, y: pt, width: pl, height: h - pt - pb, ...pFill }),
-    pr && rect({ x: w - pr, y: pt, width: pr, height: h - pt - pb, ...pFill }),
-    pb && rect({ x: 0, y: h - pb, width: w, height: pb, ...pFill }),
+    !!pt && rect({ x: 0, y: 0, width: w, height: pt, ...pFill }),
+    !!pl && rect({ x: 0, y: pt, width: pl, height: h - pt - pb, ...pFill }),
+    !!pr && rect({ x: w - pr, y: pt, width: pr, height: h - pt - pb, ...pFill }),
+    !!pb && rect({ x: 0, y: h - pb, width: w, height: pb, ...pFill }),
     // indicators for breakBefore and breakAfter
     bb === 'avoid' && circle({ cx: 5, cy: 0, r: 3, ...fill }),
     bb === 'always' && rect({ x: 0, y: -3, width: 30, height: 3, ...fill }),
@@ -37,7 +38,7 @@ export function createFrameGuides(
     // for pages, separator lines for header and footer
     page && line({ x1: -ml, y1: -mt, x2: w + mr + ml, y2: -mt, ...stroke }),
     page && line({ x1: -ml, y1: h + mb, x2: w + mr + ml, y2: h + mb, ...stroke }),
-  ].filter(Boolean) as Shape[];
+  ]);
   return { type: 'graphics', shapes };
 }
 

--- a/src/render-image.ts
+++ b/src/render-image.ts
@@ -1,7 +1,6 @@
 import {
   drawObject,
   PDFContentStream,
-  PDFOperator,
   popGraphicsState,
   pushGraphicsState,
   scale,
@@ -11,6 +10,7 @@ import {
 import { Pos } from './box.js';
 import { ImageObject } from './layout-image.js';
 import { getPageImage, Page } from './page.js';
+import { compact } from './utils.js';
 
 export function renderImage(object: ImageObject, page: Page, base: Pos) {
   const x = base.x + object.x;
@@ -19,12 +19,12 @@ export function renderImage(object: ImageObject, page: Page, base: Pos) {
   const contentStream: PDFContentStream = (page.pdfPage as any).getContentStream();
   const name = getPageImage(page, object.image);
   contentStream.push(
-    ...([
+    ...compact([
       pushGraphicsState(),
       translate(x, y),
       scale(width, height),
       drawObject(name),
       popGraphicsState(),
-    ].filter(Boolean) as PDFOperator[])
+    ])
   );
 }

--- a/src/render-text.ts
+++ b/src/render-text.ts
@@ -17,6 +17,7 @@ import {
 import { Pos } from './box.js';
 import { TextObject } from './layout.js';
 import { getPageFont, Page, TextState } from './page.js';
+import { compact } from './utils.js';
 
 export function renderText(object: TextObject, page: Page, base: Pos) {
   const contentStream: PDFContentStream = (page.pdfPage as any).getContentStream();
@@ -29,13 +30,13 @@ export function renderText(object: TextObject, page: Page, base: Pos) {
     row.segments?.forEach((seg) => {
       const fontKey = getPageFont(page, seg.font);
       const encodedText = seg.font.encodeText(seg.text);
-      const operators = [
+      const operators = compact([
         setTextColorOp(state, seg.color),
         setTextFontAndSizeOp(state, fontKey, seg.fontSize),
         setTextRiseOp(state, seg.rise),
         setLetterSpacingOp(state, seg.letterSpacing),
         showText(encodedText),
-      ].filter(Boolean) as PDFOperator[];
+      ]);
       contentStream.push(...operators);
     });
   });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,7 @@
+/**
+ * Returns a copy of the given array with all falsy values (i.e.
+ * `false`, `null`, `undefined`, `""`, `0`, and `NaN`) removed.
+ */
+export function compact<T>(array: T[]) {
+  return array.filter(Boolean) as Exclude<T, null | undefined | false>[];
+}


### PR DESCRIPTION
We sometimes include conditional values in an array and then filter out the falsy values using `filter(Boolean)`. This approach requires the use of a type assertion (using `as`) to get the correct type.

This commit introduces a util function `compact`, inspired by the lodash function of the same name, that reflects the filter in its return type.