### PR TITLE
♻️ Correct return type for pickDefined function

### DIFF
--- a/src/fonts.ts
+++ b/src/fonts.ts
@@ -53,7 +53,7 @@ export async function embedFonts(fontDefs: FontDef[], doc: PDFDocument): Promise
       const pdfFont = await doc.embedFont(def.data, { subset: true }).catch((error) => {
         throw new Error(`Could not embed font "${def.name}": ${error.message ?? error}`);
       });
-      return pickDefined({ name: def.name, italic: def.italic, bold: def.bold, pdfFont }) as Font;
+      return pickDefined({ name: def.name, italic: def.italic, bold: def.bold, pdfFont });
     })
   );
 }

--- a/src/images.ts
+++ b/src/images.ts
@@ -30,7 +30,7 @@ export async function embedImages(imageDefs: ImageDef[], doc: PDFDocument): Prom
       const pdfImage = await doc.embedJpg(def.data).catch((error) => {
         throw new Error(`Could not embed image "${def.name}": ${error.message ?? error}`);
       });
-      return pickDefined({ name: def.name, pdfImage }) as Image;
+      return pickDefined({ name: def.name, pdfImage });
     })
   );
 }

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -101,7 +101,7 @@ export function layoutPages(def: DocumentDefinition, doc: Document): Page[] {
     typeof def.header === 'function' && (page.header = layoutHeader(def.header(pageInfo), doc));
     typeof def.footer === 'function' && (page.footer = layoutFooter(def.footer(pageInfo), doc));
   });
-  return pages.map(pickDefined) as Page[];
+  return pages.map(pickDefined);
 }
 
 function layoutHeader(header: Block, doc: Document) {

--- a/src/read-block.ts
+++ b/src/read-block.ts
@@ -125,20 +125,20 @@ export function readColumnsBlock(input: Obj, defaultAttrs?: InheritableAttrs): C
   return pickDefined({
     columns: readFrom(input, 'columns', types.array(readColumn)),
     ...readBlockAttrs(input),
-  }) as ColumnsBlock;
+  });
 }
 
-export function readRowsBlock(input: Obj, defaultAttrs?: InheritableAttrs): ColumnsBlock {
+export function readRowsBlock(input: Obj, defaultAttrs?: InheritableAttrs): RowsBlock {
   const mergedAttrs = { ...defaultAttrs, ...readInheritableAttrs(input) };
   const readRow = (el: unknown) => readBlock(el, mergedAttrs);
   return pickDefined({
     rows: readFrom(input, 'rows', types.array(readRow)),
     ...readBlockAttrs(input),
-  }) as ColumnsBlock;
+  });
 }
 
 export function readEmptyBlock(input: Obj): EmptyBlock {
-  return pickDefined(readBlockAttrs(input)) as EmptyBlock;
+  return pickDefined(readBlockAttrs(input));
 }
 
 function readBlockAttrs(input: Obj): BlockAttrs {

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ export type TypeDef<T> = (input: unknown) => T;
  * @param obj The input object.
  * @returns A copy of the input object with all undefined values removed.
  */
-export function pickDefined<T extends Obj>(obj: T): Partial<T> {
+export function pickDefined<T extends Obj>(obj: T): T {
   const result = {} as T;
   for (const key in obj) {
     if (typeof obj[key] !== 'undefined') {


### PR DESCRIPTION
The `pickDefined` function strips all `undefined` values from a given object of type `T`. The return type of the function was `Partial<T>`. However, since only optional fields can be `undefined`, this function does not change the type.

This commit adjusts the return type to reflect the input type. This helps to remove some type assertions.