### PR TITLE
✨ Support inserting an extra block after page break

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
 * Attribute `breakInside` to control page breaks inside a block on
   `TextBlock` and `RowsBlock`. The default is `auto`.
 
+* Attribute `insertAfterBreak` on `RowsBlock` to insert an extra block
+  after a page break.
+
 ## [0.4.2] - 2023-04-29
 
 ### Added

--- a/examples/sample.js
+++ b/examples/sample.js
@@ -349,6 +349,7 @@ export default {
       id: `par:${n + 1}`,
       margin: { top: 5 },
       fontSize: 10,
+      insertAfterBreak: () => ({ text: '…continued', fontSize: 8, margin: { bottom: 2 } }),
     })),
   ],
 };

--- a/src/content.ts
+++ b/src/content.ts
@@ -197,6 +197,10 @@ export type RowsBlock = {
    * - `avoid`: Do not insert a page break inside this block if it can be avoided.
    */
   breakInside?: 'auto' | 'avoid';
+  /**
+   * Allows to insert an extra block after a page break.
+   */
+  insertAfterBreak?: Block | (() => Block);
 } & TextAttrs &
   BlockAttrs;
 

--- a/src/layout-rows.ts
+++ b/src/layout-rows.ts
@@ -2,7 +2,7 @@ import { Box, ZERO_EDGES } from './box.js';
 import { Document } from './document.js';
 import { Frame, isBreakPossible, layoutBlock, LayoutContent } from './layout.js';
 import { Block, RowsBlock } from './read-block.js';
-import { omit } from './utils.js';
+import { compact, omit } from './utils.js';
 
 export function layoutRowsContent(block: RowsBlock, box: Box, doc: Document): LayoutContent {
   let rowY = box.y;
@@ -27,18 +27,22 @@ export function layoutRowsContent(block: RowsBlock, box: Box, doc: Document): La
 
     const { frame, remainder } = layoutBlock(row, { ...nextPos, ...maxSize }, doc);
 
+    const performBreakAt = (breakIdx: number) => {
+      frames.splice(breakIdx);
+      const insertedBlock = block.insertAfterBreak?.();
+      remainingRows = compact([insertedBlock, remainder, ...block.rows.slice(breakIdx)]);
+    };
+
     if (frame.height + topMargin + margin.bottom > remainingHeight) {
       // This row does not fit in the remaining height. Break here if possible.
       if (lastBreakOpportunity >= 0) {
-        frames.splice(lastBreakOpportunity + 1);
-        remainingRows = block.rows.slice(lastBreakOpportunity + 1);
+        performBreakAt(lastBreakOpportunity + 1);
         break;
       } else if (block.breakInside === ('enforce-auto' as any)) {
         // There is no break opportunity, but the caller requested an auto break
         // Break here, but only if the result won't be empty
         if (rowIdx > 0) {
-          frames.splice(rowIdx);
-          remainingRows = block.rows.slice(rowIdx);
+          performBreakAt(rowIdx);
           break;
         }
       }
@@ -51,13 +55,13 @@ export function layoutRowsContent(block: RowsBlock, box: Box, doc: Document): La
 
     if (remainder) {
       // This row was split. Break here and include the remainder in the result.
-      remainingRows = [remainder, ...block.rows.slice(rowIdx + 1)];
+      performBreakAt(rowIdx + 1);
       break;
     }
 
     if (row.breakAfter === 'always' || block.rows[rowIdx + 1]?.breakBefore === 'always') {
       // A break is forced after this row. Break here.
-      remainingRows = block.rows.slice(rowIdx + 1);
+      performBreakAt(rowIdx + 1);
       break;
     }
 
@@ -72,6 +76,7 @@ export function layoutRowsContent(block: RowsBlock, box: Box, doc: Document): La
     ? // do not include the id in the remainder to avoid duplicate anchors
       { ...omit(block, 'id', 'breakInside'), rows: remainingRows }
     : undefined;
+
   return {
     frame: { height: aggregatedHeights[frames.length - 1] ?? 0, children: frames },
     remainder,

--- a/src/read-block.ts
+++ b/src/read-block.ts
@@ -36,6 +36,7 @@ export type ColumnsBlock = {
 export type RowsBlock = {
   rows: Block[];
   breakInside?: 'auto' | 'avoid';
+  insertAfterBreak?: () => Block;
 } & BlockAttrs;
 
 export type EmptyBlock = BlockAttrs;
@@ -140,6 +141,7 @@ export function readRowsBlock(input: Obj, defaultAttrs?: InheritableAttrs): Rows
     ...readObject(input, {
       rows: types.array(readRow),
       breakInside: optional(types.string({ enum: ['auto', 'avoid'] })),
+      insertAfterBreak: optional(dynamic(readBlock, 'insertAfterBreak')),
     }),
     ...readBlockAttrs(input),
   }) as RowsBlock;

--- a/test/layout-rows.test.ts
+++ b/test/layout-rows.test.ts
@@ -91,13 +91,26 @@ describe('layout-rows', () => {
         frame?.children?.map((c) => (c.objects?.[0] as any)?.name);
       const box = { x: 20, y: 30, width: 400, height: 700 };
 
-      it('includes page break after last fitting block', () => {
+      it('creates page break after last fitting block', () => {
         const rows = makeBlocks(10);
 
         const { frame, remainder } = layoutRowsContent({ rows }, box, doc);
 
         expect(renderedIds(frame)).toEqual(range(7).map(String));
         expect(remainder).toEqual({ rows: rows.slice(7) });
+      });
+
+      it('includes extra block after page break', () => {
+        const rows = makeBlocks(10);
+        const insertAfterBreak = () => ({ text: 'contd', id: 'extra' });
+
+        const { frame, remainder } = layoutRowsContent({ rows, insertAfterBreak }, box, doc);
+
+        expect(renderedIds(frame)).toEqual(range(7).map(String));
+        expect(remainder).toEqual({
+          rows: [{ text: 'contd', id: 'extra' }, ...rows.slice(7)],
+          insertAfterBreak,
+        });
       });
 
       it('supports nested rows blocks', () => {


### PR DESCRIPTION
When a page break occurs inside a block with `rows`, it may be desirable to insert an extra block just before the first element on the new page, e.g. a table header.

This commit introduces a new `insertAfterBreak` property on `RowsBlock` that allows specifying a block to insert after a page break.