### PR TITLE
🩹 Do not set default Producer and Creator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 * The attribute `margin` in a document definition now supports a
   function that returns the margin for a given page.
 
+### Fixed
+
+* In the PDF metadata, the fields "Creator" and "Producer" are no longer
+  set to default values.
+
 ## [0.5.0] - 2023-05-18
 
 ### Breaking changes

--- a/src/document.ts
+++ b/src/document.ts
@@ -23,7 +23,7 @@ export async function createDocument(def: DocumentDefinition): Promise<Document>
 }
 
 export async function renderDocument(def: DocumentDefinition, doc: Document): Promise<PDFDocument> {
-  const pdfDoc = await PDFDocument.create();
+  const pdfDoc = await PDFDocument.create({ updateMetadata: false });
   pdfDoc.registerFontkit(fontkit);
   await embedFonts(doc.fonts ?? [], pdfDoc);
   await embedImages(doc.images ?? [], pdfDoc);
@@ -51,6 +51,9 @@ export async function finishDocument(def: DocumentDefinition, pdfDoc: PDFDocumen
 }
 
 function setMetadata(doc: PDFDocument, info?: Metadata) {
+  const now = new Date();
+  doc.setCreationDate(now);
+  doc.setModificationDate(now);
   if (info?.title) {
     doc.setTitle(info.title);
   }


### PR DESCRIPTION
Previously, the Producer and Creator fields in the PDF Info dictionary have been set by pdf-lib. There was no way in PDF Maker to override it.

This commit removes the default values. Users can set these these values as needed in the document definition.