### PR TITLE
🐛 Preserve consecutive newlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 * In the PDF metadata, the fields "Creator" and "Producer" are no longer
   set to default values.
 
+* Consecutive newlines in texts are no longer collapsed. Blank lines are
+  now rendered as expected.
+
 ## [0.5.0] - 2023-05-18
 
 ### Breaking changes

--- a/src/text.ts
+++ b/src/text.ts
@@ -102,9 +102,16 @@ export function splitChunks(text: string): string[] {
   return segments;
 }
 
-export function breakLine(segments: TextSegment[], maxWidth: number) {
+export function breakLine(segments: TextSegment[], maxWidth: number): TextSegment[][] {
   const breakIdx = findLinebreak(segments, maxWidth);
-  if (breakIdx !== undefined && breakIdx >= 0) {
+  if (breakIdx === 0) {
+    // A line break is required before the first segment. Insert an
+    // empty segment with the text height of the first segment to
+    // represent a blank line and prevent collapsing of newlines.
+    const head = [{ ...segments[0], text: '', width: 0 }];
+    const tail = segments.slice(breakIdx + 1);
+    return tail.length ? [head, tail] : [head];
+  } else if (breakIdx !== undefined) {
     const head = segments.slice(0, breakIdx);
     const tail = segments.slice(breakIdx + 1);
     return tail.length ? [head, tail] : [head];

--- a/test/layout-text.test.ts
+++ b/test/layout-text.test.ts
@@ -179,12 +179,45 @@ describe('layout', () => {
       ]);
     });
 
+    it('includes blank line for consecutive newlines', () => {
+      const text = [span('foo\n\nbar', { fontSize: 10, lineHeight: 1 })];
+      const block = { text };
+
+      const { frame } = layoutTextContent(block, box, doc);
+
+      expect(frame.height).toEqual(3 * 10);
+    });
+
+    it('includes blank line with height of previous line', () => {
+      const text = [
+        span('foo\n\n', { fontSize: 10, lineHeight: 1 }),
+        span('bar', { fontSize: 20, lineHeight: 1 }),
+      ];
+      const block = { text };
+
+      const { frame } = layoutTextContent(block, box, doc);
+
+      expect(frame.height).toEqual(10 + 10 + 20);
+    });
+
+    it('includes blank line with height of next line', () => {
+      const text = [
+        span('foo\n', { fontSize: 10, lineHeight: 1 }),
+        span('\nbar', { fontSize: 20, lineHeight: 1 }),
+      ];
+      const block = { text };
+
+      const { frame } = layoutTextContent(block, box, doc);
+
+      expect(frame.height).toEqual(10 + 20 + 20);
+    });
+
     it('breaks text if it does not fit', () => {
       box.height = 100;
       const longText = range(100)
         .map(() => 'foo')
         .join(' ');
-      const text = [span(longText, { fontSize: 20, italic: true })];
+      const text = [span(longText, { fontSize: 20 })];
       const block = { text };
 
       const { remainder } = layoutTextContent(block, box, doc);
@@ -193,7 +226,7 @@ describe('layout', () => {
         text: [
           {
             text: expect.stringMatching(/^foo.*foo$/),
-            attrs: expect.objectContaining({ fontSize: 20, italic: true }),
+            attrs: expect.objectContaining({ fontSize: 20 }),
           },
         ],
       });
@@ -204,7 +237,7 @@ describe('layout', () => {
       const longText = range(100)
         .map(() => 'foo')
         .join(' ');
-      const text = [span(longText, { fontSize: 20, italic: true })];
+      const text = [span(longText, { fontSize: 20 })];
       const block = { text, breakInside: 'avoid' as const };
 
       const { remainder } = layoutTextContent(block, box, doc);

--- a/test/text.test.ts
+++ b/test/text.test.ts
@@ -210,6 +210,12 @@ describe('text', () => {
       expect(breakLine(segments, 80)).toEqual([[seg('aaa')], [seg('bbb')]]);
     });
 
+    it('breaks at leading newline segment', () => {
+      const segments = [seg('\n'), seg('aaa')];
+
+      expect(breakLine(segments, 20)).toEqual([[seg('')], [seg('aaa')]]);
+    });
+
     it('keeps unbreakable text on same line', () => {
       const segments = [seg('aaa'), seg(' '), seg('bbb')];
 
@@ -225,9 +231,9 @@ describe('text', () => {
     it('removes leading whitespace before line break', () => {
       const segments = [seg(' '), seg('aaa')];
 
-      expect(breakLine(segments, 0)).toEqual([[], [seg('aaa')]]);
-      expect(breakLine(segments, 10)).toEqual([[], [seg('aaa')]]);
-      expect(breakLine(segments, 30)).toEqual([[], [seg('aaa')]]);
+      expect(breakLine(segments, 0)).toEqual([[seg('')], [seg('aaa')]]);
+      expect(breakLine(segments, 10)).toEqual([[seg('')], [seg('aaa')]]);
+      expect(breakLine(segments, 30)).toEqual([[seg('')], [seg('aaa')]]);
       expect(breakLine(segments, 40)).toEqual([[seg(' '), seg('aaa')]]);
     });
   });


### PR DESCRIPTION
Consecutive newline characters were collapsed into a single newline. This commit fixes that by inserting empty text segments that represent blank lines.