### PR TITLE
🔧 Gitignore all .local files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,14 +12,13 @@ coverage/
 
 # temp files
 *~
+*.local
 
 # generated
 generated/
 
 # local files
 .DS_Store
-.env.local
-.env.*.local
 .eslintcache
 
 # log files


### PR DESCRIPTION
Gitignoring `*.local` keeps  `.env.local` and similar files local. This also allows for easily keeping local files and directories in the workspace.