### PR TITLE
🐛 Fix duplicated row after line break

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
   all block types. When set to `auto`, the block will shrink to the
   width of its contents.
 
+### Fixed
+
+* An edge case that could lead to a duplicated row after a page break
+  has been fixed.
+
 ## [0.5.1] - 2023-06-29
 
 ### Added

--- a/src/layout-rows.ts
+++ b/src/layout-rows.ts
@@ -32,7 +32,7 @@ export function layoutRowsContent(block: RowsBlock, box: Box, doc: Document): La
       doc
     );
 
-    const performBreakAt = (breakIdx: number) => {
+    const performBreakAt = (breakIdx: number, remainder?: Block) => {
       frames.splice(breakIdx);
       const insertedBlock = block.insertAfterBreak?.();
       remainingRows = compact([insertedBlock, remainder, ...block.rows.slice(breakIdx)]);
@@ -60,7 +60,7 @@ export function layoutRowsContent(block: RowsBlock, box: Box, doc: Document): La
 
     if (remainder) {
       // This row was split. Break here and include the remainder in the result.
-      performBreakAt(rowIdx + 1);
+      performBreakAt(rowIdx + 1, remainder);
       break;
     }
 

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -2,6 +2,7 @@ import { PDFContext, PDFDocument, PDFFont, PDFName, PDFPage, PDFRef } from 'pdf-
 
 import { Font } from '../src/fonts.js';
 import { Image } from '../src/images.js';
+import { Frame } from '../src/layout.js';
 import { Page } from '../src/page.js';
 import { TextAttrs, TextSpan } from '../src/read-block.js';
 
@@ -84,6 +85,20 @@ export function fakePDFPage(document?: PDFDocument): PDFPage {
     getContentStream: () => contentStream,
     node,
   } as unknown as PDFPage;
+}
+
+export function extractTextRows(frame: Partial<Frame>) {
+  const lines = [] as string[];
+  frame.children?.forEach((child) => {
+    child.objects?.forEach((obj) => {
+      if (obj.type === 'text') {
+        obj.rows.forEach((row) => {
+          lines.push(row.segments.map((s) => s.text).join(', '));
+        });
+      }
+    });
+  });
+  return lines;
 }
 
 export function span(text: string, attrs?: TextAttrs): TextSpan {


### PR DESCRIPTION
During the layout of a rows block, when there was not enough space left on a page for another row, the layout of that row would return an empty frame with a remainder that contained the entire row. When even this empty frame (`height: 0`) did not fit onto the old page because its margin would exceed the max height, a page break would have been inserted _before_ that frame. However, the remainder would still be prepended to the next page, resulting in a duplication of the row.

This commit fixes this bug by only prepending the remainder to the next page when the frame that accompanied this remainder is actually included in the old page, i.e. the page break is inserted _after_ that frame.