### PR TITLE
🐛 Prevent breaking text before the first row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [0.5.4] - Unreleased
 
+### Fixed
+
+- Text in a text block will no longer break before the first row, which
+  would result in an empty frame.
+
 ## [0.5.3] - 2023-09-28
 
 ### Fixed

--- a/src/layout-text.ts
+++ b/src/layout-text.ts
@@ -51,8 +51,10 @@ function layoutText(block: TextBlock, box: Box, doc: Document) {
     const { row, objects: rowObjects, remainder } = layoutResult;
 
     if (row.height > remainingSpace.height) {
-      // This row doesn't fit in the remaining space. Break here if possible.
-      if (block.breakInside !== 'avoid') {
+      // This row doesn't fit in the remaining space. Break here if
+      // possible. Do not break before the first row to avoid returning
+      // and empty frame.
+      if (block.breakInside !== 'avoid' && rows.length) {
         break;
       }
     }

--- a/test/layout-text.test.ts
+++ b/test/layout-text.test.ts
@@ -5,7 +5,7 @@ import { Box } from '../src/box.js';
 import { Document } from '../src/document.js';
 import { layoutTextContent } from '../src/layout-text.js';
 import { paperSizes } from '../src/page-sizes.js';
-import { fakeFont, range, span } from './test-utils.js';
+import { extractTextRows, fakeFont, range, span } from './test-utils.js';
 
 const { objectContaining } = expect;
 
@@ -248,8 +248,30 @@ describe('layout', () => {
       const text = [span(longText, { fontSize: 20 })];
       const block = { text };
 
-      const { remainder } = layoutTextContent(block, box, doc);
+      const { frame, remainder } = layoutTextContent(block, box, doc);
 
+      expect(extractTextRows(frame).join()).toMatch(/^foo.*foo$/);
+      expect(remainder).toEqual({
+        text: [
+          {
+            text: expect.stringMatching(/^foo.*foo$/),
+            attrs: expect.objectContaining({ fontSize: 20 }),
+          },
+        ],
+      });
+    });
+
+    it('does not break text before the first line', () => {
+      box.height = 10;
+      const longText = range(100)
+        .map(() => 'foo')
+        .join(' ');
+      const text = [span(longText, { fontSize: 20 })];
+      const block = { text };
+
+      const { frame, remainder } = layoutTextContent(block, box, doc);
+
+      expect(extractTextRows(frame).join()).toMatch(/^foo.*foo$/);
       expect(remainder).toEqual({
         text: [
           {
@@ -268,8 +290,9 @@ describe('layout', () => {
       const text = [span(longText, { fontSize: 20 })];
       const block = { text, breakInside: 'avoid' as const };
 
-      const { remainder } = layoutTextContent(block, box, doc);
+      const { frame, remainder } = layoutTextContent(block, box, doc);
 
+      expect(extractTextRows(frame).join()).toMatch(/^foo.*foo$/);
       expect(remainder).toBeUndefined();
     });
   });

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -90,13 +90,14 @@ export function fakePDFPage(document?: PDFDocument): PDFPage {
 export function extractTextRows(frame: Partial<Frame>) {
   const lines = [] as string[];
   frame.children?.forEach((child) => {
-    child.objects?.forEach((obj) => {
-      if (obj.type === 'text') {
-        obj.rows.forEach((row) => {
-          lines.push(row.segments.map((s) => s.text).join(', '));
-        });
-      }
-    });
+    extractTextRows(child).forEach((line) => lines.push(line));
+  });
+  frame.objects?.forEach((obj) => {
+    if (obj.type === 'text') {
+      obj.rows.forEach((row) => {
+        lines.push(row.segments.map((s) => s.text).join(', '));
+      });
+    }
   });
   return lines;
 }


### PR DESCRIPTION
The `layoutText` function returns a frame and optionally a remainder containing the rows that did not fit into the available space.

If even the first row did not fit, this function would return an empty frame and a remainder containing all the content. This would result in rendering an empty frame. This empty frame is not only redundant, it could even contain a misleading anchor.

This commit prevents this situation by preventing a break before the first row of text.