### PR TITLE
🔥 Remove width and height from image selector

### DIFF
--- a/src/image-loader.test.ts
+++ b/src/image-loader.test.ts
@@ -73,7 +73,7 @@ describe('image-loader', () => {
       );
     });
 
-    it('reads width and height from JPEG image', async () => {
+    it('reads format, width and height from JPEG image', async () => {
       const store = createImageStore(imageLoader);
 
       const image = await store.selectImage({ name: 'liberty' });
@@ -87,7 +87,7 @@ describe('image-loader', () => {
       });
     });
 
-    it('reads width and height from PNG image', async () => {
+    it('reads format, width and height from PNG image', async () => {
       const store = createImageStore(imageLoader);
 
       const image = await store.selectImage({ name: 'torus' });
@@ -105,11 +105,9 @@ describe('image-loader', () => {
       const store = createImageStore(imageLoader);
 
       await store.selectImage({ name: 'liberty' });
-      await store.selectImage({ name: 'liberty', width: 300 });
       await store.selectImage({ name: 'liberty' });
-      await store.selectImage({ name: 'liberty', width: 300 });
 
-      expect(imageLoader.loadImage).toHaveBeenCalledTimes(2);
+      expect(imageLoader.loadImage).toHaveBeenCalledTimes(1);
     });
 
     it('returns same image object for concurrent calls', async () => {

--- a/src/image-loader.ts
+++ b/src/image-loader.ts
@@ -49,7 +49,7 @@ export function createImageStore(imageLoader: ImageLoader): ImageStore {
   };
 
   async function selectImage(selector: ImageSelector): Promise<Image> {
-    const cacheKey = [selector.name, selector.height ?? 'any', selector.width ?? 'any'].join(':');
+    const cacheKey = selector.name;
     return (imageCache[cacheKey] ??= loadImage(selector));
   }
 
@@ -58,11 +58,9 @@ export function createImageStore(imageLoader: ImageLoader): ImageStore {
     try {
       loadedImage = await imageLoader.loadImage(selector);
     } catch (error) {
-      const selectorStr =
-        `'${selector.name}'` +
-        (selector.width != null ? `, width=${selector.width}` : '') +
-        (selector.height != null ? `, height=${selector.height}` : '');
-      throw new Error(`Could not load image ${selectorStr}: ${(error as Error)?.message ?? error}`);
+      throw new Error(
+        `Could not load image '${selector.name}': ${(error as Error)?.message ?? error}`
+      );
     }
     const { data } = loadedImage;
     const format = determineImageFormat(data);

--- a/src/images.ts
+++ b/src/images.ts
@@ -23,8 +23,6 @@ export type Image = {
 
 export type ImageSelector = {
   name: string;
-  width?: number;
-  height?: number;
 };
 
 export function readImages(input: unknown): ImageDef[] {


### PR DESCRIPTION
The width and height of an image block was passed to the image loader, but never taken into account. This commit removes the `width` and `height` attributes from the `ImageSelector` type.