### PR TITLE
🔧 Use consistent type imports

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -22,5 +22,6 @@ module.exports = {
     'import/no-default-export': 'error',
     // TODO temporarily disabled to support legacy code, re-enable
     '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/consistent-type-imports': ['error', { prefer: 'type-imports' }],
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,18 +10,18 @@
       "license": "MIT",
       "dependencies": {
         "@pdf-lib/fontkit": "^1.1.1",
-        "esbuild": "^0.20.0",
         "pdf-lib": "^1.17.1"
       },
       "devDependencies": {
-        "@types/node": "^20.11.19",
-        "@typescript-eslint/eslint-plugin": "^7.0.1",
+        "@types/node": "^20.11.20",
+        "@typescript-eslint/eslint-plugin": "^7.0.2",
+        "esbuild": "^0.20.1",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-simple-import-sort": "^12.0.0",
         "prettier": "^3.2.5",
         "typescript": "^5.3.3",
-        "vitest": "^1.3.0"
+        "vitest": "^1.3.1"
       },
       "engines": {
         "node": ">=16.13.0",
@@ -38,346 +38,17 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.0.tgz",
-      "integrity": "sha512-fGFDEctNh0CcSwsiRPxiaqX0P5rq+AqE0SRhYGZ4PX46Lg1FNR6oCxJghf8YgY0WQEgQuh3lErUFE4KxLeRmmw==",
-      "cpu": [
-        "ppc64"
-      ],
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.0.tgz",
-      "integrity": "sha512-3bMAfInvByLHfJwYPJRlpTeaQA75n8C/QKpEaiS4HrFWFiJlNI0vzq/zCjBrhAYcPyVPG7Eo9dMrcQXuqmNk5g==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.0.tgz",
-      "integrity": "sha512-aVpnM4lURNkp0D3qPoAzSG92VXStYmoVPOgXveAUoQBWRSuQzt51yvSju29J6AHPmwY1BjH49uR29oyfH1ra8Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.0.tgz",
-      "integrity": "sha512-uK7wAnlRvjkCPzh8jJ+QejFyrP8ObKuR5cBIsQZ+qbMunwR8sbd8krmMbxTLSrDhiPZaJYKQAU5Y3iMDcZPhyQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.0.tgz",
-      "integrity": "sha512-AjEcivGAlPs3UAcJedMa9qYg9eSfU6FnGHJjT8s346HSKkrcWlYezGE8VaO2xKfvvlZkgAhyvl06OJOxiMgOYQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.0.tgz",
-      "integrity": "sha512-bsgTPoyYDnPv8ER0HqnJggXK6RyFy4PH4rtsId0V7Efa90u2+EifxytE9pZnsDgExgkARy24WUQGv9irVbTvIw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.0.tgz",
-      "integrity": "sha512-kQ7jYdlKS335mpGbMW5tEe3IrQFIok9r84EM3PXB8qBFJPSc6dpWfrtsC/y1pyrz82xfUIn5ZrnSHQQsd6jebQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.0.tgz",
-      "integrity": "sha512-uG8B0WSepMRsBNVXAQcHf9+Ko/Tr+XqmK7Ptel9HVmnykupXdS4J7ovSQUIi0tQGIndhbqWLaIL/qO/cWhXKyQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.0.tgz",
-      "integrity": "sha512-2ezuhdiZw8vuHf1HKSf4TIk80naTbP9At7sOqZmdVwvvMyuoDiZB49YZKLsLOfKIr77+I40dWpHVeY5JHpIEIg==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.0.tgz",
-      "integrity": "sha512-uTtyYAP5veqi2z9b6Gr0NUoNv9F/rOzI8tOD5jKcCvRUn7T60Bb+42NDBCWNhMjkQzI0qqwXkQGo1SY41G52nw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.0.tgz",
-      "integrity": "sha512-c88wwtfs8tTffPaoJ+SQn3y+lKtgTzyjkD8NgsyCtCmtoIC8RDL7PrJU05an/e9VuAke6eJqGkoMhJK1RY6z4w==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.0.tgz",
-      "integrity": "sha512-lR2rr/128/6svngnVta6JN4gxSXle/yZEZL3o4XZ6esOqhyR4wsKyfu6qXAL04S4S5CgGfG+GYZnjFd4YiG3Aw==",
-      "cpu": [
-        "loong64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.0.tgz",
-      "integrity": "sha512-9Sycc+1uUsDnJCelDf6ZNqgZQoK1mJvFtqf2MUz4ujTxGhvCWw+4chYfDLPepMEvVL9PDwn6HrXad5yOrNzIsQ==",
-      "cpu": [
-        "mips64el"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.0.tgz",
-      "integrity": "sha512-CoWSaaAXOZd+CjbUTdXIJE/t7Oz+4g90A3VBCHLbfuc5yUQU/nFDLOzQsN0cdxgXd97lYW/psIIBdjzQIwTBGw==",
-      "cpu": [
-        "ppc64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.0.tgz",
-      "integrity": "sha512-mlb1hg/eYRJUpv8h/x+4ShgoNLL8wgZ64SUr26KwglTYnwAWjkhR2GpoKftDbPOCnodA9t4Y/b68H4J9XmmPzA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.0.tgz",
-      "integrity": "sha512-fgf9ubb53xSnOBqyvWEY6ukBNRl1mVX1srPNu06B6mNsNK20JfH6xV6jECzrQ69/VMiTLvHMicQR/PgTOgqJUQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.0.tgz",
-      "integrity": "sha512-H9Eu6MGse++204XZcYsse1yFHmRXEWgadk2N58O/xd50P9EvFMLJTQLg+lB4E1cF2xhLZU5luSWtGTb0l9UeSg==",
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.1.tgz",
+      "integrity": "sha512-5gRPk7pKuaIB+tmH+yKd2aQTRpqlf1E4f/mC+tawIm/CGJemZcHZpp2ic8oD83nKgUPMEd0fNanrnFljiruuyA==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.0.tgz",
-      "integrity": "sha512-lCT675rTN1v8Fo+RGrE5KjSnfY0x9Og4RN7t7lVrN3vMSjy34/+3na0q7RIfWDAj0e0rCh0OL+P88lu3Rt21MQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.0.tgz",
-      "integrity": "sha512-HKoUGXz/TOVXKQ+67NhxyHv+aDSZf44QpWLa3I1lLvAwGq8x1k0T+e2HHSRvxWhfJrFxaaqre1+YyzQ99KixoA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.0.tgz",
-      "integrity": "sha512-GDwAqgHQm1mVoPppGsoq4WJwT3vhnz/2N62CzhvApFD1eJyTroob30FPpOZabN+FgCjhG+AgcZyOPIkR8dfD7g==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.0.tgz",
-      "integrity": "sha512-0vYsP8aC4TvMlOQYozoksiaxjlvUcQrac+muDqj1Fxy6jh9l9CZJzj7zmh8JGfiV49cYLTorFLxg7593pGldwQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.0.tgz",
-      "integrity": "sha512-p98u4rIgfh4gdpV00IqknBD5pC84LCub+4a3MO+zjqvU5MVXOc3hqR2UgT2jI2nh3h8s9EQxmOsVI3tyzv1iFg==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.0.tgz",
-      "integrity": "sha512-NgJnesu1RtWihtTtXGFMU5YSE6JyyHPMxCwBZK7a6/8d31GuSo9l0Ss7w1Jw5QnKUawG6UEehs883kcXf5fYwg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">=12"
@@ -456,9 +127,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
-      "integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
+      "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
       "dev": true,
       "peer": true,
       "engines": {
@@ -602,110 +273,6 @@
         "pako": "^1.0.10"
       }
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.12.0.tgz",
-      "integrity": "sha512-+ac02NL/2TCKRrJu2wffk1kZ+RyqxVUlbjSagNgPm94frxtr+XDL12E5Ll1enWskLrtrZ2r8L3wED1orIibV/w==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.12.0.tgz",
-      "integrity": "sha512-OBqcX2BMe6nvjQ0Nyp7cC90cnumt8PXmO7Dp3gfAju/6YwG0Tj74z1vKrfRz7qAv23nBcYM8BCbhrsWqO7PzQQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.12.0.tgz",
-      "integrity": "sha512-X64tZd8dRE/QTrBIEs63kaOBG0b5GVEd3ccoLtyf6IdXtHdh8h+I56C2yC3PtC9Ucnv0CpNFJLqKFVgCYe0lOQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.12.0.tgz",
-      "integrity": "sha512-cc71KUZoVbUJmGP2cOuiZ9HSOP14AzBAThn3OU+9LcA1+IUqswJyR1cAJj3Mg55HbjZP6OLAIscbQsQLrpgTOg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.12.0.tgz",
-      "integrity": "sha512-a6w/Y3hyyO6GlpKL2xJ4IOh/7d+APaqLYdMf86xnczU3nurFTaVN9s9jOXQg97BE4nYm/7Ga51rjec5nfRdrvA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.12.0.tgz",
-      "integrity": "sha512-0fZBq27b+D7Ar5CQMofVN8sggOVhEtzFUwOwPppQt0k+VR+7UHMZZY4y+64WJ06XOhBTKXtQB/Sv0NwQMXyNAA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.12.0.tgz",
-      "integrity": "sha512-eTvzUS3hhhlgeAv6bfigekzWZjaEX9xP9HhxB0Dvrdbkk5w/b+1Sxct2ZuDxNJKzsRStSq1EaEkVSEe7A7ipgQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.12.0.tgz",
-      "integrity": "sha512-ix+qAB9qmrCRiaO71VFfY8rkiAZJL8zQRXveS27HS+pKdjwUfEhqo2+YF2oI+H/22Xsiski+qqwIBxVewLK7sw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.12.0.tgz",
@@ -730,45 +297,6 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.12.0.tgz",
-      "integrity": "sha512-JPDxovheWNp6d7AHCgsUlkuCKvtu3RB55iNEkaQcf0ttsDU/JZF+iQnYcQJSk/7PtT4mjjVG8N1kpwnI9SLYaw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.12.0.tgz",
-      "integrity": "sha512-fjtuvMWRGJn1oZacG8IPnzIV6GF2/XG+h71FKn76OYFqySXInJtseAqdprVTDTyqPxQOG9Exak5/E9Z3+EJ8ZA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.12.0.tgz",
-      "integrity": "sha512-ZYmr5mS2wd4Dew/JjT0Fqi2NPB/ZhZ2VvPp7SmvPZb4Y1CG/LRcS6tcRo2cYU7zLK5A7cdbhWnnWmUjoI4qapg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
       ]
     },
     "node_modules/@sinclair/typebox": {
@@ -796,9 +324,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.11.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.19.tgz",
-      "integrity": "sha512-7xMnVEcZFu0DikYjWOlRq7NTPETrm7teqUT2WkQjrTIkEgUyyGdWsj/Zg8bEJt5TNklzbPD1X3fqfsHw3SpapQ==",
+      "version": "20.11.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.20.tgz",
+      "integrity": "sha512-7/rR21OS+fq8IyHTgtLkDK949uzsa6n8BkziAKtPVpugIkO6D+/ooXMvzXxDnZrmtXVfjb1bKQafYpb8s89LOg==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -811,16 +339,16 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.0.1.tgz",
-      "integrity": "sha512-OLvgeBv3vXlnnJGIAgCLYKjgMEU+wBGj07MQ/nxAaON+3mLzX7mJbhRYrVGiVvFiXtwFlkcBa/TtmglHy0UbzQ==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.0.2.tgz",
+      "integrity": "sha512-/XtVZJtbaphtdrWjr+CJclaCVGPtOdBpFEnvtNf/jRV0IiEemRrL0qABex/nEt8isYcnFacm3nPHYQwL+Wb7qg==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "7.0.1",
-        "@typescript-eslint/type-utils": "7.0.1",
-        "@typescript-eslint/utils": "7.0.1",
-        "@typescript-eslint/visitor-keys": "7.0.1",
+        "@typescript-eslint/scope-manager": "7.0.2",
+        "@typescript-eslint/type-utils": "7.0.2",
+        "@typescript-eslint/utils": "7.0.2",
+        "@typescript-eslint/visitor-keys": "7.0.2",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -846,16 +374,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.0.1.tgz",
-      "integrity": "sha512-8GcRRZNzaHxKzBPU3tKtFNing571/GwPBeCvmAUw0yBtfE2XVd0zFKJIMSWkHJcPQi0ekxjIts6L/rrZq5cxGQ==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.0.2.tgz",
+      "integrity": "sha512-GdwfDglCxSmU+QTS9vhz2Sop46ebNCXpPPvsByK7hu0rFGRHL+AusKQJ7SoN+LbLh6APFpQwHKmDSwN35Z700Q==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "7.0.1",
-        "@typescript-eslint/types": "7.0.1",
-        "@typescript-eslint/typescript-estree": "7.0.1",
-        "@typescript-eslint/visitor-keys": "7.0.1",
+        "@typescript-eslint/scope-manager": "7.0.2",
+        "@typescript-eslint/types": "7.0.2",
+        "@typescript-eslint/typescript-estree": "7.0.2",
+        "@typescript-eslint/visitor-keys": "7.0.2",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -875,13 +403,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.0.1.tgz",
-      "integrity": "sha512-v7/T7As10g3bcWOOPAcbnMDuvctHzCFYCG/8R4bK4iYzdFqsZTbXGln0cZNVcwQcwewsYU2BJLay8j0/4zOk4w==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.0.2.tgz",
+      "integrity": "sha512-l6sa2jF3h+qgN2qUMjVR3uCNGjWw4ahGfzIYsCtFrQJCjhbrDPdiihYT8FnnqFwsWX+20hK592yX9I2rxKTP4g==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.0.1",
-        "@typescript-eslint/visitor-keys": "7.0.1"
+        "@typescript-eslint/types": "7.0.2",
+        "@typescript-eslint/visitor-keys": "7.0.2"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -892,13 +420,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.0.1.tgz",
-      "integrity": "sha512-YtT9UcstTG5Yqy4xtLiClm1ZpM/pWVGFnkAa90UfdkkZsR1eP2mR/1jbHeYp8Ay1l1JHPyGvoUYR6o3On5Nhmw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.0.2.tgz",
+      "integrity": "sha512-IKKDcFsKAYlk8Rs4wiFfEwJTQlHcdn8CLwLaxwd6zb8HNiMcQIFX9sWax2k4Cjj7l7mGS5N1zl7RCHOVwHq2VQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "7.0.1",
-        "@typescript-eslint/utils": "7.0.1",
+        "@typescript-eslint/typescript-estree": "7.0.2",
+        "@typescript-eslint/utils": "7.0.2",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -919,9 +447,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.0.1.tgz",
-      "integrity": "sha512-uJDfmirz4FHib6ENju/7cz9SdMSkeVvJDK3VcMFvf/hAShg8C74FW+06MaQPODHfDJp/z/zHfgawIJRjlu0RLg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.0.2.tgz",
+      "integrity": "sha512-ZzcCQHj4JaXFjdOql6adYV4B/oFOFjPOC9XYwCaZFRvqN8Llfvv4gSxrkQkd2u4Ci62i2c6W6gkDwQJDaRc4nA==",
       "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -932,13 +460,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.0.1.tgz",
-      "integrity": "sha512-SO9wHb6ph0/FN5OJxH4MiPscGah5wjOd0RRpaLvuBv9g8565Fgu0uMySFEPqwPHiQU90yzJ2FjRYKGrAhS1xig==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.0.2.tgz",
+      "integrity": "sha512-3AMc8khTcELFWcKcPc0xiLviEvvfzATpdPj/DXuOGIdQIIFybf4DMT1vKRbuAEOFMwhWt7NFLXRkbjsvKZQyvw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.0.1",
-        "@typescript-eslint/visitor-keys": "7.0.1",
+        "@typescript-eslint/types": "7.0.2",
+        "@typescript-eslint/visitor-keys": "7.0.2",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -960,17 +488,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.0.1.tgz",
-      "integrity": "sha512-oe4his30JgPbnv+9Vef1h48jm0S6ft4mNwi9wj7bX10joGn07QRfqIqFHoMiajrtoU88cIhXf8ahwgrcbNLgPA==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.0.2.tgz",
+      "integrity": "sha512-PZPIONBIB/X684bhT1XlrkjNZJIEevwkKDsdwfiu1WeqBxYEEdIgVDgm8/bbKHVu+6YOpeRqcfImTdImx/4Bsw==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "7.0.1",
-        "@typescript-eslint/types": "7.0.1",
-        "@typescript-eslint/typescript-estree": "7.0.1",
+        "@typescript-eslint/scope-manager": "7.0.2",
+        "@typescript-eslint/types": "7.0.2",
+        "@typescript-eslint/typescript-estree": "7.0.2",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -985,12 +513,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.0.1.tgz",
-      "integrity": "sha512-hwAgrOyk++RTXrP4KzCg7zB2U0xt7RUU0ZdMSCsqF3eKUwkdXUMyTb0qdCuji7VIbcpG62kKTU9M1J1c9UpFBw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.0.2.tgz",
+      "integrity": "sha512-8Y+YiBmqPighbm5xA2k4wKTxRzx9EkBu7Rlw+WHqMvRJ3RPz/BMBO9b2ru0LUNmXg120PHUXD5+SWFy2R8DqlQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.0.1",
+        "@typescript-eslint/types": "7.0.2",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -1009,13 +537,13 @@
       "peer": true
     },
     "node_modules/@vitest/expect": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.3.0.tgz",
-      "integrity": "sha512-7bWt0vBTZj08B+Ikv70AnLRicohYwFgzNjFqo9SxxqHHxSlUJGSXmCRORhOnRMisiUryKMdvsi1n27Bc6jL9DQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.3.1.tgz",
+      "integrity": "sha512-xofQFwIzfdmLLlHa6ag0dPV8YsnKOCP1KdAeVVh34vSjN2dcUiXYCD9htu/9eM7t8Xln4v03U9HLxLpPlsXdZw==",
       "dev": true,
       "dependencies": {
-        "@vitest/spy": "1.3.0",
-        "@vitest/utils": "1.3.0",
+        "@vitest/spy": "1.3.1",
+        "@vitest/utils": "1.3.1",
         "chai": "^4.3.10"
       },
       "funding": {
@@ -1023,12 +551,12 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.3.0.tgz",
-      "integrity": "sha512-1Jb15Vo/Oy7mwZ5bXi7zbgszsdIBNjc4IqP8Jpr/8RdBC4nF1CTzIAn2dxYvpF1nGSseeL39lfLQ2uvs5u1Y9A==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.3.1.tgz",
+      "integrity": "sha512-5FzF9c3jG/z5bgCnjr8j9LNq/9OxV2uEBAITOXfoe3rdZJTdO7jzThth7FXv/6b+kdY65tpRQB7WaKhNZwX+Kg==",
       "dev": true,
       "dependencies": {
-        "@vitest/utils": "1.3.0",
+        "@vitest/utils": "1.3.1",
         "p-limit": "^5.0.0",
         "pathe": "^1.1.1"
       },
@@ -1064,9 +592,9 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.3.0.tgz",
-      "integrity": "sha512-swmktcviVVPYx9U4SEQXLV6AEY51Y6bZ14jA2yo6TgMxQ3h+ZYiO0YhAHGJNp0ohCFbPAis1R9kK0cvN6lDPQA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.3.1.tgz",
+      "integrity": "sha512-EF++BZbt6RZmOlE3SuTPu/NfwBF6q4ABS37HHXzs2LUVPBLx2QoY/K0fKpRChSo8eLiuxcbCVfqKgx/dplCDuQ==",
       "dev": true,
       "dependencies": {
         "magic-string": "^0.30.5",
@@ -1078,9 +606,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.3.0.tgz",
-      "integrity": "sha512-AkCU0ThZunMvblDpPKgjIi025UxR8V7MZ/g/EwmAGpjIujLVV2X6rGYGmxE2D4FJbAy0/ijdROHMWa2M/6JVMw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.3.1.tgz",
+      "integrity": "sha512-xAcW+S099ylC9VLU7eZfdT9myV67Nor9w9zhf0mGCYJSO+zM2839tOeROTdikOi/8Qeusffvxb/MyBSOja1Uig==",
       "dev": true,
       "dependencies": {
         "tinyspy": "^2.2.0"
@@ -1090,9 +618,9 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-/LibEY/fkaXQufi4GDlQZhikQsPO2entBKtfuyIpr1jV4DpaeasqkeHjhdOhU24vSHshcSuEyVlWdzvv2XmYCw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.3.1.tgz",
+      "integrity": "sha512-d3Waie/299qqRyHTm2DjADeTaNdNSVsnwHPWrs20JMpjh6eiVq7ggggweO8rc4arhf6rRkWuHKwvxGvejUXZZQ==",
       "dev": true,
       "dependencies": {
         "diff-sequences": "^29.6.3",
@@ -1335,10 +863,13 @@
       }
     },
     "node_modules/available-typed-arrays": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.6.tgz",
-      "integrity": "sha512-j1QzY8iPNPG4o4xmO3ptzpRxTciqD3MgEHtifP/YnJpIo58Xu+ne4BejlbkuaLfXn/nz6HFiw29bLpj2PNMdGg==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
       "dev": true,
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -1685,14 +1216,14 @@
       }
     },
     "node_modules/es-set-tostringtag": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.2.tgz",
-      "integrity": "sha512-BuDyupZt65P9D2D2vA/zqcI3G5xRsklm5N3xCwuiy+/vKy8i0ifdsQP1sLgO4tZDSCaQUSnmC48khknGMV3D2Q==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
+      "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
       "dev": true,
       "dependencies": {
-        "get-intrinsic": "^1.2.2",
-        "has-tostringtag": "^1.0.0",
-        "hasown": "^2.0.0"
+        "get-intrinsic": "^1.2.4",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1725,9 +1256,10 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.0.tgz",
-      "integrity": "sha512-6iwE3Y2RVYCME1jLpBqq7LQWK3MW6vjV2bZy6gt/WrqkY+WE74Spyc0ThAOYpMtITvnjX09CrC6ym7A/m9mebA==",
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.1.tgz",
+      "integrity": "sha512-OJwEgrpWm/PCMsLVWXKqvcjme3bHNpOgN7Tb6cQnR5n0TPbQx1/Xrn7rqM+wn17bYeT6MGB5sn1Bh5YiGi70nA==",
+      "dev": true,
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -1736,29 +1268,29 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.20.0",
-        "@esbuild/android-arm": "0.20.0",
-        "@esbuild/android-arm64": "0.20.0",
-        "@esbuild/android-x64": "0.20.0",
-        "@esbuild/darwin-arm64": "0.20.0",
-        "@esbuild/darwin-x64": "0.20.0",
-        "@esbuild/freebsd-arm64": "0.20.0",
-        "@esbuild/freebsd-x64": "0.20.0",
-        "@esbuild/linux-arm": "0.20.0",
-        "@esbuild/linux-arm64": "0.20.0",
-        "@esbuild/linux-ia32": "0.20.0",
-        "@esbuild/linux-loong64": "0.20.0",
-        "@esbuild/linux-mips64el": "0.20.0",
-        "@esbuild/linux-ppc64": "0.20.0",
-        "@esbuild/linux-riscv64": "0.20.0",
-        "@esbuild/linux-s390x": "0.20.0",
-        "@esbuild/linux-x64": "0.20.0",
-        "@esbuild/netbsd-x64": "0.20.0",
-        "@esbuild/openbsd-x64": "0.20.0",
-        "@esbuild/sunos-x64": "0.20.0",
-        "@esbuild/win32-arm64": "0.20.0",
-        "@esbuild/win32-ia32": "0.20.0",
-        "@esbuild/win32-x64": "0.20.0"
+        "@esbuild/aix-ppc64": "0.20.1",
+        "@esbuild/android-arm": "0.20.1",
+        "@esbuild/android-arm64": "0.20.1",
+        "@esbuild/android-x64": "0.20.1",
+        "@esbuild/darwin-arm64": "0.20.1",
+        "@esbuild/darwin-x64": "0.20.1",
+        "@esbuild/freebsd-arm64": "0.20.1",
+        "@esbuild/freebsd-x64": "0.20.1",
+        "@esbuild/linux-arm": "0.20.1",
+        "@esbuild/linux-arm64": "0.20.1",
+        "@esbuild/linux-ia32": "0.20.1",
+        "@esbuild/linux-loong64": "0.20.1",
+        "@esbuild/linux-mips64el": "0.20.1",
+        "@esbuild/linux-ppc64": "0.20.1",
+        "@esbuild/linux-riscv64": "0.20.1",
+        "@esbuild/linux-s390x": "0.20.1",
+        "@esbuild/linux-x64": "0.20.1",
+        "@esbuild/netbsd-x64": "0.20.1",
+        "@esbuild/openbsd-x64": "0.20.1",
+        "@esbuild/sunos-x64": "0.20.1",
+        "@esbuild/win32-arm64": "0.20.1",
+        "@esbuild/win32-ia32": "0.20.1",
+        "@esbuild/win32-x64": "0.20.1"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -1775,17 +1307,17 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
-      "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
+      "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
         "@eslint/eslintrc": "^2.1.4",
-        "@eslint/js": "8.56.0",
-        "@humanwhocodes/config-array": "^0.11.13",
+        "@eslint/js": "8.57.0",
+        "@humanwhocodes/config-array": "^0.11.14",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "@ungap/structured-clone": "^1.2.0",
@@ -2105,6 +1637,29 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2221,9 +1776,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
-      "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
+      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true,
       "peer": true
     },
@@ -2242,20 +1797,6 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true,
       "peer": true
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -2319,6 +1860,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-symbol-description": {
@@ -2497,9 +2050,9 @@
       }
     },
     "node_modules/has-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
@@ -2545,6 +2098,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.17.0"
       }
     },
     "node_modules/ignore": {
@@ -2720,9 +2282,9 @@
       }
     },
     "node_modules/is-negative-zero": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
-      "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
@@ -2782,15 +2344,30 @@
       }
     },
     "node_modules/is-shared-array-buffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
-      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2"
+        "call-bind": "^1.0.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-string": {
@@ -2862,6 +2439,12 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "node_modules/js-tokens": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-8.0.3.tgz",
+      "integrity": "sha512-UfJMcSJc+SEXEl9lH/VLHSZbThQyLpw1vLO1Lb+j4RWDvG3N2f7yj3PVQA3cmkTBNldJ9eFnM+xEXxHIXrYiJw==",
+      "dev": true
+    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -2895,6 +2478,18 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
     },
     "node_modules/jsonc-parser": {
       "version": "3.2.1",
@@ -2974,6 +2569,18 @@
         "get-func-name": "^2.0.1"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.7",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.7.tgz",
@@ -3014,6 +2621,18 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
@@ -3039,9 +2658,9 @@
       }
     },
     "node_modules/mlly": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.5.0.tgz",
-      "integrity": "sha512-NPVQvAY1xr1QoVeG0cy8yUYC7FQcOx6evl/RjT1wL5FvzPnzOysoqB/jmx/DhssT2dYa8nxECLAaFI/+gVLhDQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.6.1.tgz",
+      "integrity": "sha512-vLgaHvaeunuOXHSmEbZ9izxPx3USsk8KCQ8iC+aTlp5sKRSoZvwhHh5L9VbKSaVC6sJDqbyohIS76E2VmHIPAA==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.11.3",
@@ -3079,6 +2698,33 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/object-inspect": {
       "version": "1.13.1",
@@ -3171,6 +2817,21 @@
       "peer": true,
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/optionator": {
@@ -3338,6 +2999,15 @@
         "jsonc-parser": "^3.2.0",
         "mlly": "^1.2.0",
         "pathe": "^1.1.0"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
+      "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
@@ -3631,24 +3301,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/semver/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semver/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
     "node_modules/set-function-length": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.1.tgz",
@@ -3667,14 +3319,15 @@
       }
     },
     "node_modules/set-function-name": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
-      "integrity": "sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
       "dev": true,
       "dependencies": {
-        "define-data-property": "^1.0.1",
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
         "functions-have-names": "^1.2.3",
-        "has-property-descriptors": "^1.0.0"
+        "has-property-descriptors": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3724,6 +3377,18 @@
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/slash": {
       "version": "3.0.0",
@@ -3813,6 +3478,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -3837,12 +3523,6 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
-    },
-    "node_modules/strip-literal/node_modules/js-tokens": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-8.0.3.tgz",
-      "integrity": "sha512-UfJMcSJc+SEXEl9lH/VLHSZbThQyLpw1vLO1Lb+j4RWDvG3N2f7yj3PVQA3cmkTBNldJ9eFnM+xEXxHIXrYiJw==",
-      "dev": true
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -3936,27 +3616,6 @@
         "strip-bom": "^3.0.0"
       }
     },
-    "node_modules/tsconfig-paths/node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/tsconfig-paths/node_modules/strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -3998,12 +3657,12 @@
       }
     },
     "node_modules/typed-array-buffer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.1.tgz",
-      "integrity": "sha512-RSqu1UEuSlrBhHTWC8O9FnPjOduNs4M7rJ4pRKoEjtx1zUNOPN2sSXHLDX+Y2WPbHIxbvg4JFo2DNAEfPIKWoQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.6",
+        "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
         "is-typed-array": "^1.1.13"
       },
@@ -4012,15 +3671,16 @@
       }
     },
     "node_modules/typed-array-byte-length": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.0.tgz",
-      "integrity": "sha512-Or/+kvLxNpeQ9DtSydonMxCx+9ZXOswtwJn17SNLvhptaXYDJvkFFP5zbfU/uLmvnBJlI4yrnXRxpdWH/M5tNA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
+      "integrity": "sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
+        "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
-        "has-proto": "^1.0.1",
-        "is-typed-array": "^1.1.10"
+        "gopd": "^1.0.1",
+        "has-proto": "^1.0.3",
+        "is-typed-array": "^1.1.13"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4030,16 +3690,16 @@
       }
     },
     "node_modules/typed-array-byte-offset": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.1.tgz",
-      "integrity": "sha512-tcqKMrTRXjqvHN9S3553NPCaGL0VPgFI92lXszmrE8DMhiDPLBYLlvo8Uu4WZAAX/aGqp/T1sbA4ph8EWjDF9Q==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.2.tgz",
+      "integrity": "sha512-Ous0vodHa56FviZucS2E63zkgtgrACj7omjwd/8lTEMEPFFyjfixMZ1ZXenpgCFBBt4EC1J2XsyVS2gkG0eTFA==",
       "dev": true,
       "dependencies": {
-        "available-typed-arrays": "^1.0.6",
+        "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
         "gopd": "^1.0.1",
-        "has-proto": "^1.0.1",
+        "has-proto": "^1.0.3",
         "is-typed-array": "^1.1.13"
       },
       "engines": {
@@ -4050,14 +3710,20 @@
       }
     },
     "node_modules/typed-array-length": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
-      "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.5.tgz",
+      "integrity": "sha512-yMi0PlwuznKHxKmcpoOdeLwxBoVPkqZxd7q2FgMkmD3bNwvF5VW0+UlUQ1k1vmktTu4Yu13Q0RIxEP8+B+wloA==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
+        "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
-        "is-typed-array": "^1.1.9"
+        "gopd": "^1.0.1",
+        "has-proto": "^1.0.3",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4114,9 +3780,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.3.tgz",
-      "integrity": "sha512-UfmUD36DKkqhi/F75RrxvPpry+9+tTkrXfMNZD+SboZqBCMsxKtO52XeGzzuh7ioz+Eo/SYDBbdb0Z7vgcDJew==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.4.tgz",
+      "integrity": "sha512-n+MPqzq+d9nMVTKyewqw6kSt+R3CkvF9QAKY8obiQn8g1fwTscKxyfaYnC632HtBXAQGc1Yjomphwn1dtwGAHg==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.19.3",
@@ -4169,9 +3835,9 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.3.0.tgz",
-      "integrity": "sha512-D/oiDVBw75XMnjAXne/4feCkCEwcbr2SU1bjAhCcfI5Bq3VoOHji8/wCPAfUkDIeohJ5nSZ39fNxM3dNZ6OBOA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.3.1.tgz",
+      "integrity": "sha512-azbRrqRxlWTJEVbzInZCTchx0X69M/XPTCz4H+TLvlTcR/xH/3hkRqhOakT41fMJCMzXTu4UvegkZiEoJAWvng==",
       "dev": true,
       "dependencies": {
         "cac": "^6.7.14",
@@ -4190,262 +3856,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.12.tgz",
-      "integrity": "sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-arm": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.12.tgz",
-      "integrity": "sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-arm64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.12.tgz",
-      "integrity": "sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-x64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.12.tgz",
-      "integrity": "sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.12.tgz",
-      "integrity": "sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.12.tgz",
-      "integrity": "sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.12.tgz",
-      "integrity": "sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.12.tgz",
-      "integrity": "sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-arm": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.12.tgz",
-      "integrity": "sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.12.tgz",
-      "integrity": "sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.12.tgz",
-      "integrity": "sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.12.tgz",
-      "integrity": "sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.12.tgz",
-      "integrity": "sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.12.tgz",
-      "integrity": "sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.12.tgz",
-      "integrity": "sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.12.tgz",
-      "integrity": "sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/vite/node_modules/@esbuild/linux-x64": {
       "version": "0.19.12",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.12.tgz",
@@ -4457,102 +3867,6 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.12.tgz",
-      "integrity": "sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.12.tgz",
-      "integrity": "sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.12.tgz",
-      "integrity": "sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.12.tgz",
-      "integrity": "sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.12.tgz",
-      "integrity": "sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-x64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.12.tgz",
-      "integrity": "sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">=12"
@@ -4597,16 +3911,16 @@
       }
     },
     "node_modules/vitest": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.3.0.tgz",
-      "integrity": "sha512-V9qb276J1jjSx9xb75T2VoYXdO1UKi+qfflY7V7w93jzX7oA/+RtYE6TcifxksxsZvygSSMwu2Uw6di7yqDMwg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.3.1.tgz",
+      "integrity": "sha512-/1QJqXs8YbCrfv/GPQ05wAZf2eakUPLPa18vkJAKE7RXOKfVHqMZZ1WlTjiwl6Gcn65M5vpNUB6EFLnEdRdEXQ==",
       "dev": true,
       "dependencies": {
-        "@vitest/expect": "1.3.0",
-        "@vitest/runner": "1.3.0",
-        "@vitest/snapshot": "1.3.0",
-        "@vitest/spy": "1.3.0",
-        "@vitest/utils": "1.3.0",
+        "@vitest/expect": "1.3.1",
+        "@vitest/runner": "1.3.1",
+        "@vitest/snapshot": "1.3.1",
+        "@vitest/spy": "1.3.1",
+        "@vitest/utils": "1.3.1",
         "acorn-walk": "^8.3.2",
         "chai": "^4.3.10",
         "debug": "^4.3.4",
@@ -4620,7 +3934,7 @@
         "tinybench": "^2.5.1",
         "tinypool": "^0.8.2",
         "vite": "^5.0.0",
-        "vite-node": "1.3.0",
+        "vite-node": "1.3.1",
         "why-is-node-running": "^2.2.2"
       },
       "bin": {
@@ -4635,8 +3949,8 @@
       "peerDependencies": {
         "@edge-runtime/vm": "*",
         "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "1.3.0",
-        "@vitest/ui": "1.3.0",
+        "@vitest/browser": "1.3.1",
+        "@vitest/ui": "1.3.1",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -4659,140 +3973,6 @@
         "jsdom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vitest/node_modules/execa": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^8.0.1",
-        "human-signals": "^5.0.0",
-        "is-stream": "^3.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^5.1.0",
-        "onetime": "^6.0.0",
-        "signal-exit": "^4.1.0",
-        "strip-final-newline": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.17"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/vitest/node_modules/get-stream": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/vitest/node_modules/human-signals": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=16.17.0"
-      }
-    },
-    "node_modules/vitest/node_modules/is-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-      "dev": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/vitest/node_modules/mimic-fn": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/vitest/node_modules/npm-run-path": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.2.0.tgz",
-      "integrity": "sha512-W4/tgAXFqFA0iL7fk0+uQ3g7wkL8xJmx3XdK0VGb4cHW//eZTtKGvFBBoRKVTpY7n6ze4NL9ly7rgXcHufqXKg==",
-      "dev": true,
-      "dependencies": {
-        "path-key": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/vitest/node_modules/onetime": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-      "dev": true,
-      "dependencies": {
-        "mimic-fn": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/vitest/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/vitest/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/vitest/node_modules/strip-final-newline": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/which": {
@@ -4867,6 +4047,12 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -27,21 +27,22 @@
   "scripts": {
     "build": "rm -rf dist/ && tsc && esbuild src/index.ts --bundle --sourcemap --platform=node --target=es2021,node18 --outdir=dist --format=esm --external:pdf-lib --external:@pdf-lib/fontkit",
     "lint": "eslint '{src,test}/**/*.{js,ts}' --max-warnings 0 --format visualstudio && prettier --check .",
-    "test": "vitest run test"
+    "test": "vitest run test",
+    "fix": "eslint '{src,test}/**/*.{js,ts}' --fix && prettier -w ."
   },
   "dependencies": {
     "@pdf-lib/fontkit": "^1.1.1",
-    "esbuild": "^0.20.0",
     "pdf-lib": "^1.17.1"
   },
   "devDependencies": {
-    "@types/node": "^20.11.19",
-    "@typescript-eslint/eslint-plugin": "^7.0.1",
+    "@types/node": "^20.11.20",
+    "@typescript-eslint/eslint-plugin": "^7.0.2",
+    "esbuild": "^0.20.1",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-simple-import-sort": "^12.0.0",
     "prettier": "^3.2.5",
     "typescript": "^5.3.3",
-    "vitest": "^1.3.0"
+    "vitest": "^1.3.1"
   }
 }

--- a/src/api/content.ts
+++ b/src/api/content.ts
@@ -1,6 +1,6 @@
-import { Color } from './colors.ts';
-import { Length } from './sizes.ts';
-import { Orientation, PaperSize } from './sizes.ts';
+import type { Color } from './colors.ts';
+import type { Length } from './sizes.ts';
+import type { Orientation, PaperSize } from './sizes.ts';
 
 /**
  * The complete definition of a document to create.

--- a/src/api/make-pdf.ts
+++ b/src/api/make-pdf.ts
@@ -4,7 +4,7 @@ import { layoutPages } from '../layout/layout.ts';
 import { readDocumentDefinition } from '../read-document.ts';
 import { renderDocument } from '../render/render-document.ts';
 import { readAs } from '../types.ts';
-import { DocumentDefinition } from './content.ts';
+import type { DocumentDefinition } from './content.ts';
 
 /**
  * Generates a PDF from the given document definition.

--- a/src/box.ts
+++ b/src/box.ts
@@ -1,4 +1,5 @@
-import { isObject, Obj, typeError } from './types.ts';
+import type { Obj } from './types.ts';
+import { isObject, typeError } from './types.ts';
 
 export type Pos = { x: number; y: number };
 export type Size = { width: number; height: number };

--- a/src/font-loader.test.ts
+++ b/src/font-loader.test.ts
@@ -2,7 +2,7 @@ import fontkit from '@pdf-lib/fontkit';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { FontLoader, FontStore } from './font-loader.ts';
-import { Font, FontDef, FontSelector } from './fonts.ts';
+import type { Font, FontDef, FontSelector } from './fonts.ts';
 import { fakeFont, mkData } from './test/test-utils.ts';
 
 describe('font-loader', () => {

--- a/src/font-loader.ts
+++ b/src/font-loader.ts
@@ -1,8 +1,9 @@
 import fontkit from '@pdf-lib/fontkit';
 import { toUint8Array } from 'pdf-lib';
 
-import { FontWeight } from './api/content.ts';
-import { Font, FontDef, FontSelector, weightToNumber } from './fonts.ts';
+import type { FontWeight } from './api/content.ts';
+import type { Font, FontDef, FontSelector } from './fonts.ts';
+import { weightToNumber } from './fonts.ts';
 import { pickDefined } from './types.ts';
 
 export type LoadedFont = {

--- a/src/font-metrics.ts
+++ b/src/font-metrics.ts
@@ -1,4 +1,4 @@
-import { Font } from '@pdf-lib/fontkit';
+import type { Font } from '@pdf-lib/fontkit';
 
 export function getTextWidth(text: string, font: Font, fontSize: number): number {
   const { glyphs } = font.layout(text);

--- a/src/fonts.ts
+++ b/src/fonts.ts
@@ -1,7 +1,8 @@
-import fontkit from '@pdf-lib/fontkit';
-import { CustomFontSubsetEmbedder, PDFDocument, PDFFont, PDFRef } from 'pdf-lib';
+import type fontkit from '@pdf-lib/fontkit';
+import type { PDFDocument, PDFRef } from 'pdf-lib';
+import { CustomFontSubsetEmbedder, PDFFont } from 'pdf-lib';
 
-import { FontStyle, FontWeight } from './api/content.ts';
+import type { FontStyle, FontWeight } from './api/content.ts';
 import { parseBinaryData } from './binary-data.ts';
 import { printValue } from './print-value.ts';
 import { optional, readAs, readBoolean, readObject, required, types } from './types.ts';

--- a/src/frame.ts
+++ b/src/frame.ts
@@ -1,7 +1,7 @@
-import { Font } from './fonts.ts';
-import { Image } from './images.ts';
-import { Color } from './read-color.ts';
-import { PathCommand } from './svg-paths.ts';
+import type { Font } from './fonts.ts';
+import type { Image } from './images.ts';
+import type { Color } from './read-color.ts';
+import type { PathCommand } from './svg-paths.ts';
 
 /**
  * Frames are created during the layout process. They have a position

--- a/src/guides.ts
+++ b/src/guides.ts
@@ -1,7 +1,7 @@
 import { rgb } from 'pdf-lib';
 
 import { ZERO_EDGES } from './box.ts';
-import {
+import type {
   CircleObject,
   Frame,
   GraphicsObject,
@@ -9,7 +9,7 @@ import {
   RectObject,
   TextRowObject,
 } from './frame.ts';
-import { Block } from './read-block.ts';
+import type { Block } from './read-block.ts';
 import { compact } from './utils.ts';
 
 export function createFrameGuides(

--- a/src/image-loader.test.ts
+++ b/src/image-loader.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ImageLoader, ImageStore } from './image-loader.ts';
-import { ImageSelector } from './images.ts';
+import type { ImageSelector } from './images.ts';
 
 global.crypto ??= (crypto as any).webcrypto;
 

--- a/src/image-loader.ts
+++ b/src/image-loader.ts
@@ -2,7 +2,7 @@ import { readFile } from 'node:fs/promises';
 
 import { toUint8Array } from 'pdf-lib';
 
-import { Image, ImageDef, ImageFormat, ImageSelector } from './images.ts';
+import type { Image, ImageDef, ImageFormat, ImageSelector } from './images.ts';
 import { isJpeg, readJpegInfo } from './images/jpeg.ts';
 import { isPng, readPngInfo } from './images/png.ts';
 

--- a/src/images.test.ts
+++ b/src/images.test.ts
@@ -4,7 +4,8 @@ import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import { Image, readImages, registerImage } from './images.ts';
+import type { Image } from './images.ts';
+import { readImages, registerImage } from './images.ts';
 import { fakePDFDocument, mkData } from './test/test-utils.ts';
 
 global.crypto ??= (crypto as any).webcrypto;

--- a/src/images.ts
+++ b/src/images.ts
@@ -1,4 +1,5 @@
-import { JpegEmbedder, PDFDocument, PDFRef, PngEmbedder } from 'pdf-lib';
+import type { PDFDocument, PDFRef } from 'pdf-lib';
+import { JpegEmbedder, PngEmbedder } from 'pdf-lib';
 
 import { parseBinaryData } from './binary-data.ts';
 import { optional, readAs, readObject, required, types } from './types.ts';

--- a/src/layout/layout-columns.test.ts
+++ b/src/layout/layout-columns.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { Box } from '../box.ts';
-import { FontStore } from '../font-loader.ts';
-import { MakerCtx } from '../maker-ctx.ts';
-import { Block } from '../read-block.ts';
+import type { Box } from '../box.ts';
+import type { FontStore } from '../font-loader.ts';
+import type { MakerCtx } from '../maker-ctx.ts';
+import type { Block } from '../read-block.ts';
 import { fakeFont, span } from '../test/test-utils.ts';
 import { layoutColumnsContent } from './layout-columns.ts';
 

--- a/src/layout/layout-columns.ts
+++ b/src/layout/layout-columns.ts
@@ -1,8 +1,9 @@
-import { Box } from '../box.ts';
-import { Frame } from '../frame.ts';
-import { MakerCtx } from '../maker-ctx.ts';
-import { Block, ColumnsBlock } from '../read-block.ts';
-import { layoutBlock, LayoutContent } from './layout.ts';
+import type { Box } from '../box.ts';
+import type { Frame } from '../frame.ts';
+import type { MakerCtx } from '../maker-ctx.ts';
+import type { Block, ColumnsBlock } from '../read-block.ts';
+import type { LayoutContent } from './layout.ts';
+import { layoutBlock } from './layout.ts';
 
 export async function layoutColumnsContent(
   block: ColumnsBlock,

--- a/src/layout/layout-image.test.ts
+++ b/src/layout/layout-image.test.ts
@@ -1,10 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { Box } from '../box.ts';
-import { ImageStore } from '../image-loader.ts';
-import { ImageSelector } from '../images.ts';
-import { MakerCtx } from '../maker-ctx.ts';
-import { ImageBlock } from '../read-block.ts';
+import type { Box } from '../box.ts';
+import type { ImageStore } from '../image-loader.ts';
+import type { ImageSelector } from '../images.ts';
+import type { MakerCtx } from '../maker-ctx.ts';
+import type { ImageBlock } from '../read-block.ts';
 import { fakeImage } from '../test/test-utils.ts';
 import { layoutImageContent } from './layout-image.ts';
 

--- a/src/layout/layout-image.ts
+++ b/src/layout/layout-image.ts
@@ -1,9 +1,9 @@
-import { Box, Pos, Size } from '../box.ts';
-import { ImageObject, RenderObject } from '../frame.ts';
-import { Image } from '../images.ts';
-import { MakerCtx } from '../maker-ctx.ts';
-import { ImageBlock } from '../read-block.ts';
-import { LayoutContent } from './layout.ts';
+import type { Box, Pos, Size } from '../box.ts';
+import type { ImageObject, RenderObject } from '../frame.ts';
+import type { Image } from '../images.ts';
+import type { MakerCtx } from '../maker-ctx.ts';
+import type { ImageBlock } from '../read-block.ts';
+import type { LayoutContent } from './layout.ts';
 
 export async function layoutImageContent(
   block: ImageBlock,

--- a/src/layout/layout-rows.test.ts
+++ b/src/layout/layout-rows.test.ts
@@ -1,10 +1,10 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { Box } from '../box.ts';
-import { FontStore } from '../font-loader.ts';
-import { Frame } from '../frame.ts';
-import { MakerCtx } from '../maker-ctx.ts';
-import { Block } from '../read-block.ts';
+import type { Box } from '../box.ts';
+import type { FontStore } from '../font-loader.ts';
+import type { Frame } from '../frame.ts';
+import type { MakerCtx } from '../maker-ctx.ts';
+import type { Block } from '../read-block.ts';
 import { extractTextRows, fakeFont, range, span } from '../test/test-utils.ts';
 import { layoutRowsContent } from './layout-rows.ts';
 

--- a/src/layout/layout-rows.ts
+++ b/src/layout/layout-rows.ts
@@ -1,9 +1,11 @@
-import { Box, ZERO_EDGES } from '../box.ts';
-import { Frame } from '../frame.ts';
-import { MakerCtx } from '../maker-ctx.ts';
-import { Block, RowsBlock } from '../read-block.ts';
+import type { Box } from '../box.ts';
+import { ZERO_EDGES } from '../box.ts';
+import type { Frame } from '../frame.ts';
+import type { MakerCtx } from '../maker-ctx.ts';
+import type { Block, RowsBlock } from '../read-block.ts';
 import { compact, omit } from '../utils.ts';
-import { isBreakPossible, layoutBlock, LayoutContent } from './layout.ts';
+import type { LayoutContent } from './layout.ts';
+import { isBreakPossible, layoutBlock } from './layout.ts';
 
 export async function layoutRowsContent(
   block: RowsBlock,

--- a/src/layout/layout-text.test.ts
+++ b/src/layout/layout-text.test.ts
@@ -1,10 +1,10 @@
 import { rgb } from 'pdf-lib';
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { Box } from '../box.ts';
-import { FontStore } from '../font-loader.ts';
-import { Font, FontSelector } from '../fonts.ts';
-import { MakerCtx } from '../maker-ctx.ts';
+import type { Box } from '../box.ts';
+import type { FontStore } from '../font-loader.ts';
+import type { Font, FontSelector } from '../fonts.ts';
+import type { MakerCtx } from '../maker-ctx.ts';
 import { extractTextRows, fakeFont, range, span } from '../test/test-utils.ts';
 import { layoutTextContent } from './layout-text.ts';
 

--- a/src/layout/layout-text.ts
+++ b/src/layout/layout-text.ts
@@ -1,18 +1,13 @@
-import { Box, Size } from '../box.ts';
-import { Font } from '../fonts.ts';
-import { LinkObject, RenderObject, TextRowObject, TextSegmentObject } from '../frame.ts';
+import type { Box, Size } from '../box.ts';
+import type { Font } from '../fonts.ts';
+import type { LinkObject, RenderObject, TextRowObject, TextSegmentObject } from '../frame.ts';
 import { createRowGuides } from '../guides.ts';
-import { MakerCtx } from '../maker-ctx.ts';
-import { TextBlock } from '../read-block.ts';
-import {
-  breakLine,
-  convertToTextSpan,
-  extractTextSegments,
-  flattenTextSegments,
-  TextSegment,
-} from '../text.ts';
+import type { MakerCtx } from '../maker-ctx.ts';
+import type { TextBlock } from '../read-block.ts';
+import type { TextSegment } from '../text.ts';
+import { breakLine, convertToTextSpan, extractTextSegments, flattenTextSegments } from '../text.ts';
 import { omit } from '../utils.ts';
-import { LayoutContent } from './layout.ts';
+import type { LayoutContent } from './layout.ts';
 
 export async function layoutTextContent(
   block: TextBlock,

--- a/src/layout/layout.test.ts
+++ b/src/layout/layout.test.ts
@@ -1,11 +1,12 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { paperSizes } from '../api/sizes.ts';
-import { Box } from '../box.ts';
-import { FontStore } from '../font-loader.ts';
-import { MakerCtx } from '../maker-ctx.ts';
-import { Block, TextAttrs, TextSpan } from '../read-block.ts';
-import { PageInfo, readDocumentDefinition } from '../read-document.ts';
+import type { Box } from '../box.ts';
+import type { FontStore } from '../font-loader.ts';
+import type { MakerCtx } from '../maker-ctx.ts';
+import type { Block, TextAttrs, TextSpan } from '../read-block.ts';
+import type { PageInfo } from '../read-document.ts';
+import { readDocumentDefinition } from '../read-document.ts';
 import { fakeFont, p, range } from '../test/test-utils.ts';
 import { isBreakPossible, layoutBlock, layoutPages } from './layout.ts';
 

--- a/src/layout/layout.ts
+++ b/src/layout/layout.ts
@@ -1,11 +1,12 @@
 import { paperSizes } from '../api/sizes.ts';
-import { Box, parseEdges, Size, subtractEdges, ZERO_EDGES } from '../box.ts';
-import { AnchorObject, Frame } from '../frame.ts';
+import type { Box, Size } from '../box.ts';
+import { parseEdges, subtractEdges, ZERO_EDGES } from '../box.ts';
+import type { AnchorObject, Frame } from '../frame.ts';
 import { createFrameGuides } from '../guides.ts';
-import { MakerCtx } from '../maker-ctx.ts';
-import { Page } from '../page.ts';
-import { Block, RowsBlock } from '../read-block.ts';
-import { DocumentDefinition } from '../read-document.ts';
+import type { MakerCtx } from '../maker-ctx.ts';
+import type { Page } from '../page.ts';
+import type { Block, RowsBlock } from '../read-block.ts';
+import type { DocumentDefinition } from '../read-document.ts';
 import { applyOrientation } from '../read-page-size.ts';
 import { pickDefined } from '../types.ts';
 import { layoutColumnsContent } from './layout-columns.ts';

--- a/src/maker-ctx.ts
+++ b/src/maker-ctx.ts
@@ -1,5 +1,5 @@
-import { FontStore } from './font-loader.ts';
-import { ImageStore } from './image-loader.ts';
+import type { FontStore } from './font-loader.ts';
+import type { ImageStore } from './image-loader.ts';
 
 export type MakerCtx = {
   fontStore: FontStore;

--- a/src/page.test.ts
+++ b/src/page.test.ts
@@ -1,8 +1,9 @@
-import { PDFPage } from 'pdf-lib';
+import type { PDFPage } from 'pdf-lib';
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { Font } from './fonts.ts';
-import { addPageFont, getExtGraphicsState, Page } from './page.ts';
+import type { Font } from './fonts.ts';
+import type { Page } from './page.ts';
+import { addPageFont, getExtGraphicsState } from './page.ts';
 import { fakeFont, fakePDFPage } from './test/test-utils.ts';
 
 describe('page', () => {

--- a/src/page.ts
+++ b/src/page.ts
@@ -1,9 +1,11 @@
-import { Color, PDFName, PDFPage } from 'pdf-lib';
+import type { Color, PDFName, PDFPage } from 'pdf-lib';
 
-import { Size } from './box.ts';
-import { Font, registerFont } from './fonts.ts';
-import { Frame } from './frame.ts';
-import { Image, registerImage } from './images.ts';
+import type { Size } from './box.ts';
+import type { Font } from './fonts.ts';
+import { registerFont } from './fonts.ts';
+import type { Frame } from './frame.ts';
+import type { Image } from './images.ts';
+import { registerImage } from './images.ts';
 
 export type TextState = {
   color?: Color;

--- a/src/read-block.ts
+++ b/src/read-block.ts
@@ -1,18 +1,19 @@
-import { Alignment, FontStyle, FontWeight } from './api/content.ts';
-import { BoxEdges, parseEdges, parseLength } from './box.ts';
-import { Shape } from './frame.ts';
-import { Color, readColor } from './read-color.ts';
+import type { Alignment, FontStyle, FontWeight } from './api/content.ts';
+import type { BoxEdges } from './box.ts';
+import { parseEdges, parseLength } from './box.ts';
+import type { Shape } from './frame.ts';
+import type { Color } from './read-color.ts';
+import { readColor } from './read-color.ts';
 import { readShape } from './read-graphics.ts';
+import type { Obj, TypeDef } from './types.ts';
 import {
   dynamic,
   isObject,
-  Obj,
   optional,
   pickDefined,
   readFrom,
   readObject,
   required,
-  TypeDef,
   typeError,
   types,
 } from './types.ts';

--- a/src/read-document.test.ts
+++ b/src/read-document.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { PageInfo, readDocumentDefinition } from './read-document.ts';
+import type { PageInfo } from './read-document.ts';
+import { readDocumentDefinition } from './read-document.ts';
 
 describe('read-document', () => {
   describe('readDocumentDefinition', () => {

--- a/src/read-document.ts
+++ b/src/read-document.ts
@@ -1,9 +1,14 @@
-import { BoxEdges, parseEdges, Size } from './box.ts';
-import { FontDef, readFonts } from './fonts.ts';
-import { ImageDef, readImages } from './images.ts';
-import { Block, readBlock, readInheritableAttrs, TextAttrs } from './read-block.ts';
+import type { BoxEdges, Size } from './box.ts';
+import { parseEdges } from './box.ts';
+import type { FontDef } from './fonts.ts';
+import { readFonts } from './fonts.ts';
+import type { ImageDef } from './images.ts';
+import { readImages } from './images.ts';
+import type { Block, TextAttrs } from './read-block.ts';
+import { readBlock, readInheritableAttrs } from './read-block.ts';
 import { parseOrientation, readPageSize } from './read-page-size.ts';
-import { dynamic, Obj, optional, readAs, readObject, required, typeError, types } from './types.ts';
+import type { Obj } from './types.ts';
+import { dynamic, optional, readAs, readObject, required, typeError, types } from './types.ts';
 
 export type DocumentDefinition = {
   fonts?: FontDef[];

--- a/src/read-graphics.ts
+++ b/src/read-graphics.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   CircleObject,
   LineObject,
   PathObject,
@@ -8,7 +8,8 @@ import {
 } from './frame.ts';
 import { readColor } from './read-color.ts';
 import { parseSvgPath } from './svg-paths.ts';
-import { Obj, optional, readFrom, readObject, required, types } from './types.ts';
+import type { Obj } from './types.ts';
+import { optional, readFrom, readObject, required, types } from './types.ts';
 import { omit } from './utils.ts';
 
 const tLineCap = types.string({ enum: ['butt', 'round', 'square'] });

--- a/src/read-page-size.ts
+++ b/src/read-page-size.ts
@@ -1,5 +1,6 @@
 import { paperSizes } from './api/sizes.ts';
-import { parseLength, Size } from './box.ts';
+import type { Size } from './box.ts';
+import { parseLength } from './box.ts';
 import { isObject, readFrom, required, typeError } from './types.ts';
 
 export function readPageSize(def?: unknown): Size {

--- a/src/render/render-annotations.ts
+++ b/src/render/render-annotations.ts
@@ -1,8 +1,9 @@
-import { PDFArray, PDFDict, PDFName, PDFPage, PDFString } from 'pdf-lib';
+import type { PDFArray, PDFDict, PDFPage } from 'pdf-lib';
+import { PDFName, PDFString } from 'pdf-lib';
 
-import { Box, Pos } from '../box.ts';
-import { AnchorObject, LinkObject } from '../frame.ts';
-import { Page } from '../page.ts';
+import type { Box, Pos } from '../box.ts';
+import type { AnchorObject, LinkObject } from '../frame.ts';
+import type { Page } from '../page.ts';
 
 export function renderAnchor(obj: AnchorObject, page: Page, base: Pos) {
   const x = base.x + obj.x;

--- a/src/render/render-document.test.ts
+++ b/src/render/render-document.test.ts
@@ -1,6 +1,7 @@
 import crypto from 'node:crypto';
 
-import { PDFDict, PDFDocument, PDFHexString, PDFName, PDFStream, PDFString } from 'pdf-lib';
+import type { PDFStream } from 'pdf-lib';
+import { PDFDict, PDFDocument, PDFHexString, PDFName, PDFString } from 'pdf-lib';
 import { describe, expect, it } from 'vitest';
 
 import { renderDocument } from './render-document.ts';

--- a/src/render/render-document.ts
+++ b/src/render/render-document.ts
@@ -1,7 +1,8 @@
-import { PDFDict, PDFDocument, PDFHexString, PDFName } from 'pdf-lib';
+import type { PDFDict } from 'pdf-lib';
+import { PDFDocument, PDFHexString, PDFName } from 'pdf-lib';
 
-import { Page } from '../page.ts';
-import { DocumentDefinition, Metadata } from '../read-document.ts';
+import type { Page } from '../page.ts';
+import type { DocumentDefinition, Metadata } from '../read-document.ts';
 import { renderPage } from './render-page.ts';
 
 export async function renderDocument(def: DocumentDefinition, pages: Page[]): Promise<Uint8Array> {

--- a/src/render/render-graphics.test.ts
+++ b/src/render/render-graphics.test.ts
@@ -1,9 +1,9 @@
 import { rgb } from 'pdf-lib';
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { Size } from '../box.ts';
-import { CircleObject, LineObject, PathObject, PolylineObject, RectObject } from '../frame.ts';
-import { Page } from '../page.ts';
+import type { Size } from '../box.ts';
+import type { CircleObject, LineObject, PathObject, PolylineObject, RectObject } from '../frame.ts';
+import type { Page } from '../page.ts';
 import { fakePDFPage, getContentStream, p } from '../test/test-utils.ts';
 import { renderGraphics } from './render-graphics.ts';
 

--- a/src/render/render-graphics.ts
+++ b/src/render/render-graphics.ts
@@ -1,3 +1,4 @@
+import type { PDFName } from 'pdf-lib';
 import {
   appendBezierCurve,
   asPDFNumber,
@@ -9,7 +10,6 @@ import {
   LineJoinStyle,
   lineTo,
   moveTo,
-  PDFName,
   PDFOperator,
   popGraphicsState,
   pushGraphicsState,
@@ -23,9 +23,9 @@ import {
   stroke,
 } from 'pdf-lib';
 
-import { LineCap, LineJoin } from '../api/content.ts';
-import { Pos } from '../box.ts';
-import {
+import type { LineCap, LineJoin } from '../api/content.ts';
+import type { Pos } from '../box.ts';
+import type {
   CircleObject,
   FillAttrs,
   GraphicsObject,
@@ -36,7 +36,8 @@ import {
   RectObject,
   Shape,
 } from '../frame.ts';
-import { getExtGraphicsState, Page } from '../page.ts';
+import type { Page } from '../page.ts';
+import { getExtGraphicsState } from '../page.ts';
 import { svgPathToPdfOps } from '../svg-paths.ts';
 import { compact, multiplyMatrices, round } from '../utils.ts';
 

--- a/src/render/render-image.test.ts
+++ b/src/render/render-image.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { Size } from '../box.ts';
-import { ImageObject } from '../frame.ts';
-import { Image } from '../images.ts';
-import { Page } from '../page.ts';
+import type { Size } from '../box.ts';
+import type { ImageObject } from '../frame.ts';
+import type { Image } from '../images.ts';
+import type { Page } from '../page.ts';
 import { fakePDFPage, getContentStream } from '../test/test-utils.ts';
 import { renderImage } from './render-image.ts';
 

--- a/src/render/render-image.ts
+++ b/src/render/render-image.ts
@@ -1,15 +1,10 @@
-import {
-  drawObject,
-  PDFContentStream,
-  popGraphicsState,
-  pushGraphicsState,
-  scale,
-  translate,
-} from 'pdf-lib';
+import type { PDFContentStream } from 'pdf-lib';
+import { drawObject, popGraphicsState, pushGraphicsState, scale, translate } from 'pdf-lib';
 
-import { Pos } from '../box.ts';
-import { ImageObject } from '../frame.ts';
-import { addPageImage, Page } from '../page.ts';
+import type { Pos } from '../box.ts';
+import type { ImageObject } from '../frame.ts';
+import type { Page } from '../page.ts';
+import { addPageImage } from '../page.ts';
 import { compact } from '../utils.ts';
 
 export function renderImage(object: ImageObject, page: Page, base: Pos) {

--- a/src/render/render-page.test.ts
+++ b/src/render/render-page.test.ts
@@ -1,10 +1,11 @@
-import { PDFArray, PDFDict, PDFDocument, PDFName, PDFPage, PDFRef } from 'pdf-lib';
+import type { PDFDocument, PDFPage } from 'pdf-lib';
+import { PDFArray, PDFDict, PDFName, PDFRef } from 'pdf-lib';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { Size } from '../box.ts';
-import { Font } from '../fonts.ts';
-import { Frame } from '../frame.ts';
-import { Page } from '../page.ts';
+import type { Size } from '../box.ts';
+import type { Font } from '../fonts.ts';
+import type { Frame } from '../frame.ts';
+import type { Page } from '../page.ts';
 import { fakeFont, fakePDFPage, getContentStream } from '../test/test-utils.ts';
 import { renderFrame, renderPage } from './render-page.ts';
 

--- a/src/render/render-page.ts
+++ b/src/render/render-page.ts
@@ -1,8 +1,8 @@
-import { PDFDocument } from 'pdf-lib';
+import type { PDFDocument } from 'pdf-lib';
 
-import { Pos } from '../box.ts';
-import { Frame } from '../frame.ts';
-import { Page } from '../page.ts';
+import type { Pos } from '../box.ts';
+import type { Frame } from '../frame.ts';
+import type { Page } from '../page.ts';
 import { renderAnchor, renderLink } from './render-annotations.ts';
 import { renderGraphics } from './render-graphics.ts';
 import { renderImage } from './render-image.ts';

--- a/src/render/render-text.test.ts
+++ b/src/render/render-text.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { Size } from '../box.ts';
-import { Font } from '../fonts.ts';
-import { TextObject } from '../frame.ts';
-import { Page } from '../page.ts';
+import type { Size } from '../box.ts';
+import type { Font } from '../fonts.ts';
+import type { TextObject } from '../frame.ts';
+import type { Page } from '../page.ts';
 import { fakeFont, fakePDFPage, getContentStream } from '../test/test-utils.ts';
 import { renderText } from './render-text.ts';
 

--- a/src/render/render-text.ts
+++ b/src/render/render-text.ts
@@ -1,11 +1,7 @@
+import type { Color, PDFContentStream, PDFFont, PDFName, PDFOperator } from 'pdf-lib';
 import {
   beginText,
-  Color,
   endText,
-  PDFContentStream,
-  PDFFont,
-  PDFName,
-  PDFOperator,
   rgb,
   setCharacterSpacing,
   setFillingColor,
@@ -15,9 +11,10 @@ import {
   showText,
 } from 'pdf-lib';
 
-import { Pos } from '../box.ts';
-import { TextObject } from '../frame.ts';
-import { addPageFont, Page, TextState } from '../page.ts';
+import type { Pos } from '../box.ts';
+import type { TextObject } from '../frame.ts';
+import type { Page, TextState } from '../page.ts';
+import { addPageFont } from '../page.ts';
 import { compact } from '../utils.ts';
 
 export function renderText(object: TextObject, page: Page, base: Pos) {

--- a/src/svg-paths.ts
+++ b/src/svg-paths.ts
@@ -1,11 +1,5 @@
-import {
-  appendBezierCurve,
-  appendQuadraticCurve,
-  closePath,
-  lineTo,
-  moveTo,
-  PDFOperator,
-} from 'pdf-lib';
+import type { PDFOperator } from 'pdf-lib';
+import { appendBezierCurve, appendQuadraticCurve, closePath, lineTo, moveTo } from 'pdf-lib';
 
 import { arcToSegments, segmentToBezier } from './arcs.ts';
 

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -1,10 +1,12 @@
-import { PDFContext, PDFDocument, PDFFont, PDFName, PDFPage, PDFRef } from 'pdf-lib';
+import type { PDFDocument, PDFFont, PDFPage } from 'pdf-lib';
+import { PDFContext, PDFName, PDFRef } from 'pdf-lib';
 
-import { Font, weightToNumber } from '../fonts.ts';
-import { Frame } from '../frame.ts';
-import { Image } from '../images.ts';
-import { Page } from '../page.ts';
-import { TextAttrs, TextSpan } from '../read-block.ts';
+import type { Font } from '../fonts.ts';
+import { weightToNumber } from '../fonts.ts';
+import type { Frame } from '../frame.ts';
+import type { Image } from '../images.ts';
+import type { Page } from '../page.ts';
+import type { TextAttrs, TextSpan } from '../read-block.ts';
 
 export function fakeFont(
   name: string,

--- a/src/text.test.ts
+++ b/src/text.test.ts
@@ -1,16 +1,16 @@
 import { rgb } from 'pdf-lib';
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { FontStore } from './font-loader.ts';
-import { Font } from './fonts.ts';
+import type { FontStore } from './font-loader.ts';
+import type { Font } from './fonts.ts';
 import { fakeFont } from './test/test-utils.ts';
+import type { TextSegment } from './text.ts';
 import {
   breakLine,
   extractTextSegments,
   findLinebreakOpportunity,
   flattenTextSegments,
   splitChunks,
-  TextSegment,
 } from './text.ts';
 
 const { objectContaining } = expect;

--- a/src/text.ts
+++ b/src/text.ts
@@ -1,9 +1,9 @@
-import { FontStyle, FontWeight } from './api/content.ts';
-import { FontStore } from './font-loader.ts';
+import type { FontStyle, FontWeight } from './api/content.ts';
+import type { FontStore } from './font-loader.ts';
 import { getTextHeight, getTextWidth } from './font-metrics.ts';
-import { Font } from './fonts.ts';
-import { TextSpan } from './read-block.ts';
-import { Color } from './read-color.ts';
+import type { Font } from './fonts.ts';
+import type { TextSpan } from './read-block.ts';
+import type { Color } from './read-color.ts';
 
 const defaultFontSize = 18;
 const defaultLineHeight = 1.2;


### PR DESCRIPTION
The `type` keyword on imports indicates that the imported type exists only in the typings, but is not available at runtime. Those imports can cause errors if they end up in the JavaScript package.

By consistently using this keyword, those imports can be stripped from the output by `esbuild`.