### PR TITLE
🔧 Only include public API types in package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,11 @@
 *
 
 !package.json
-!dist/**/*
 !LICENSE.*
 !CHANGELOG.*
 !README.*
+
+!dist/*.js
+!dist/*.js.map
+!dist/index.d.ts
+!dist/api/*.d.ts

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "stripInternal": true
   },
   "include": ["src/**/*.ts", "src/**/*.d.ts"],
   "exclude": ["node_modules", "dist", "src/**/test/", "src/**/*.test.ts"]


### PR DESCRIPTION
The package should not contains any internal type definitions. This commit excludes any `*.d.ts` files other than the `index.d.ts` and the `d.ts` files in the `api` folder from the package. All API is contained in this folder.

The `stripInternal` option is added to the `tsconfig.json` to allow marking any internal types or functions in this folder with `@internal`.