### PR TITLE
⬆️ Require Node 20, npm 10

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '18.x'
+          node-version: '20.x'
       - run: npm ci
       - run: npm run lint
       - run: npm run test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [0.5.5] - Unreleased
 
+Minimum requirements bumped to Node 20 and npm 10.
+
 ### Deprecated
 
 - `TextAttrs` in favor of `TextProps`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -32,39 +32,11 @@ If you're using [Deno], you can skip this step.
 
 ## Run the examples
 
-### Node
-
-Node.js does not yet expose the [WebCrypto API] in the global scope.
-Since PDF Maker uses this API, the `--experimental-global-webcrypto`
-flag must be used:
-
 ```sh
-$ node --experimental-global-webcrypto src/hello-world.js
-```
-
-Alternatively, you can expose the API in the global scope yourself:
-
-```js
-import * as crypto from 'crypto';
-global.crypto ??= crypto;
-```
-
-Also note that Node.js still relies on the `module: true` flag in the
-`package.json` file to enable ESM mode.
-
-### Bun
-
-[Bun] works out of the box:
-
-```sh
+$ node src/hello-world.js
+# OR
 $ bun run src/hello-world.js
-```
-
-### Deno
-
-[Deno] works out of the box:
-
-```sh
+# OR
 $ deno run --allow-read --allow-write src/hello-world.js
 ```
 
@@ -80,4 +52,3 @@ $ bun run --watch src/hello-world.js
 [Node]: https://nodejs.org/en/
 [Bun]: https://bun.sh/
 [Deno]: https://deno.land/
-[WebCrypto API]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,8 +25,8 @@
         "vitest": "^2.1.2"
       },
       "engines": {
-        "node": ">=16.13.0",
-        "npm": ">=8"
+        "node": ">=20",
+        "npm": ">=10"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "module": "./dist/index.js"
   },
   "engines": {
-    "node": ">=16.13.0",
-    "npm": ">=8"
+    "node": ">=20",
+    "npm": ">=10"
   },
   "scripts": {
     "build": "rm -rf build/ dist/ && tsc && esbuild src/index.ts --bundle --sourcemap --platform=node --target=es2021,node18 --outdir=dist --format=esm --external:pdf-lib --external:@pdf-lib/fontkit && cp -a build/index.d.ts build/api/ dist/",

--- a/src/api/make-pdf.test.ts
+++ b/src/api/make-pdf.test.ts
@@ -1,10 +1,6 @@
-import crypto from 'node:crypto';
-
 import { describe, expect, it } from 'vitest';
 
 import { makePdf } from './make-pdf.ts';
-
-global.crypto ??= (crypto as any).webcrypto;
 
 describe('make-pdf', () => {
   describe('makePdf', () => {

--- a/src/image-loader.test.ts
+++ b/src/image-loader.test.ts
@@ -1,4 +1,3 @@
-import crypto from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
@@ -6,8 +5,6 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ImageLoader, ImageStore } from './image-loader.ts';
 import type { ImageSelector } from './images.ts';
-
-global.crypto ??= (crypto as any).webcrypto;
 
 describe('image-loader', () => {
   let libertyJpg: Uint8Array;

--- a/src/images.test.ts
+++ b/src/images.test.ts
@@ -1,4 +1,3 @@
-import crypto from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
@@ -7,8 +6,6 @@ import { describe, expect, it } from 'vitest';
 import type { Image } from './images.ts';
 import { readImages, registerImage } from './images.ts';
 import { fakePDFDocument, mkData } from './test/test-utils.ts';
-
-global.crypto ??= (crypto as any).webcrypto;
 
 describe('images', () => {
   describe('readImages', () => {


### PR DESCRIPTION
Node.js version 20 is the current LTS version. Node.js 18 will be end-of-life in April 2025. This commit updates the minimum required Node.js version to 20.

Node 20 supports ESM out of the box. The WebCrypto API is available in the global scope. The `--experimental-global-webcrypto` flag is no longer needed to run the examples.

The manual exposure of the API in the global scope has been removed from the tests.