### PR TITLE
✨ Introduce PdfMaker class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ Minimum requirements bumped to Node 20 and npm 10.
 - The functions `text()`, `image()`, `rows()`, and `columns()` to create
   blocks with less code and better tool support.
 
+- The `PdfMaker` class to render multiple documents with the same
+  font configuration.
+
+  ```ts
+  const pdfMaker = new PdfMaker(config);
+  pdfMaker.registerFont(await readFile('path/to/MyFont.ttf'));
+  pdfMaker.registerFont(await readFile('path/to/MyFont-Bold.ttf'));
+  const pdf1 = await pdfMaker.makePdf(doc1);
+  const pdf2 = await pdfMaker.makePdf(doc2);
+  ```
+
 ### Deprecated
 
 - `TextAttrs` in favor of `TextProps`.
@@ -26,6 +37,9 @@ Minimum requirements bumped to Node 20 and npm 10.
 - `RectOpts` in favor of `RectProps`.
 - `CircleOpts` in favor of `CircleProps`.
 - `PathOpts` in favor of `PathProps`.
+- The `fonts` property in a document definition.
+- The `makePdf` function in favor of the `makePdf` method on the
+  `PdfMaker` class.
 
 ## [0.5.4] - 2024-02-25
 

--- a/src/api/PdfMaker.ts
+++ b/src/api/PdfMaker.ts
@@ -1,0 +1,56 @@
+import { FontStore } from '../font-store.ts';
+import { ImageStore } from '../image-store.ts';
+import { layoutPages } from '../layout/layout.ts';
+import type { MakerCtx } from '../maker-ctx.ts';
+import { readDocumentDefinition } from '../read-document.ts';
+import { renderDocument } from '../render/render-document.ts';
+import { readAs } from '../types.ts';
+import type { DocumentDefinition } from './document.ts';
+import type { FontStyle, FontWeight } from './text.ts';
+
+export type FontConfig = {
+  name?: string;
+  style?: FontStyle;
+  weight?: FontWeight;
+};
+
+/**
+ * Generates PDF documents.
+ */
+export class PdfMaker {
+  #ctx: MakerCtx;
+
+  constructor() {
+    const fontStore = new FontStore([]);
+    const imageStore = new ImageStore([]);
+    this.#ctx = { fontStore, imageStore };
+  }
+
+  /**
+   * Registers a font to be used in generated PDFs.
+   *
+   * @param data The font data. Must be in OpenType (OTF) or TrueType
+   * (TTF) format.
+   * @param config Additional configuration of the font, only needed if
+   * the meta data cannot be extracted from the font.
+   */
+  registerFont(data: Uint8Array, config?: FontConfig): void {
+    this.#ctx.fontStore.registerFont(data, config);
+  }
+
+  /**
+   * Generates a PDF from the given document definition.
+   *
+   * @param definition The definition of the document to generate.
+   * @returns The generated PDF document.
+   */
+  async makePdf(definition: DocumentDefinition): Promise<Uint8Array> {
+    const def = readAs(definition, 'definition', readDocumentDefinition);
+    const ctx = { ...this.#ctx };
+    if (def.fonts) ctx.fontStore = new FontStore(def.fonts);
+    if (def.images) ctx.imageStore = new ImageStore(def.images);
+    if (def.dev?.guides != null) ctx.guides = def.dev.guides;
+    const pages = await layoutPages(def, ctx);
+    return await renderDocument(def, pages);
+  }
+}

--- a/src/api/document.ts
+++ b/src/api/document.ts
@@ -54,6 +54,8 @@ export type DocumentDefinition = {
   /**
    * The fonts to use in the document. There is no default. Each font that is used in the document
    * must be registered. Not needed for documents that contain only graphics.
+   *
+   * @deprecated Register fonts with `PdfMaker` instead.
    */
   fonts?: FontsDefinition;
 
@@ -153,11 +155,15 @@ export type CustomInfoProps = {
 
 /**
  * An object that defines the fonts to use in the document.
+ *
+ * @deprecated Register fonts with `PdfMaker` instead.
  */
 export type FontsDefinition = { [name: string]: FontDefinition[] };
 
 /**
  * The definition of a single font.
+ *
+ * @deprecated Register fonts with `PdfMaker` instead.
  */
 export type FontDefinition = {
   /**

--- a/src/api/make-pdf.ts
+++ b/src/api/make-pdf.ts
@@ -11,6 +11,9 @@ import type { DocumentDefinition } from './document.ts';
  *
  * @param definition The definition of the document to generate.
  * @returns The generated PDF document.
+ *
+ * @deprecated Create an instance of `PdfMaker` and call `makePdf` on
+ * that instance.
  */
 export async function makePdf(definition: DocumentDefinition): Promise<Uint8Array> {
   const def = readAs(definition, 'definition', readDocumentDefinition);

--- a/src/fonts.ts
+++ b/src/fonts.ts
@@ -15,6 +15,7 @@ export type FontDef = {
   style: FontStyle;
   weight: number;
   data: string | Uint8Array | ArrayBuffer;
+  fkFont?: fontkit.Font;
 };
 
 export type Font = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import * as document from './api/document.ts';
 import * as graphics from './api/graphics.ts';
 import * as layout from './api/layout.ts';
 import * as makePdf from './api/make-pdf.ts';
+import * as pdfMaker from './api/PdfMaker.ts';
 import * as sizes from './api/sizes.ts';
 import * as text from './api/text.ts';
 
@@ -12,6 +13,7 @@ export const pdf = {
   ...graphics,
   ...layout,
   ...makePdf,
+  ...pdfMaker,
   ...sizes,
   ...text,
 };
@@ -21,5 +23,6 @@ export * from './api/document.ts';
 export * from './api/graphics.ts';
 export * from './api/layout.ts';
 export * from './api/make-pdf.ts';
+export * from './api/PdfMaker.ts';
 export * from './api/sizes.ts';
 export * from './api/text.ts';


### PR DESCRIPTION
So far, font data had to be embedded directly within the document definition, despite being more logically associated with the renderer than the document itself. This also made it hard to inspect or debug document definitions due to the inclusion of large binary font data.

This commit introduces a new `PdfMaker` class that replaces the `makePdf` function. This class allows font data to be registered separately and reused across multiple documents. With this approach, font data is no longer part of the document definition.

Example:

```ts
const pdfMaker = new PdfMaker();
pdfMaker.registerFont(await readFile('path/to/MyFont.ttf'));
pdfMaker.registerFont(await readFile('path/to/MyFont-Bold.ttf'));
const pdf1 = await pdfMaker.makePdf(doc1);
const pdf2 = await pdfMaker.makePdf(doc2);
```