### PR TITLE
🐛 Fix TypeError for color on nested blocks

### DIFF
--- a/src/read-color.test.ts
+++ b/src/read-color.test.ts
@@ -22,6 +22,11 @@ describe('readColor', () => {
     expect(readColor('blue')).toEqual({ type: 'RGB', red: 0, green: 0, blue: 1 });
   });
 
+  it('accepts its own output', () => {
+    // See https://github.com/eclipsesource/pdf-maker/issues/95
+    expect(readColor(readColor('red'))).toEqual({ type: 'RGB', red: 1, green: 0, blue: 0 });
+  });
+
   it('throws on unsupported named color', () => {
     expect(() => readColor('' as any)).toThrowError("Expected valid color name, got: ''");
     expect(() => readColor('salmon' as any)).toThrowError(

--- a/src/read-color.ts
+++ b/src/read-color.ts
@@ -1,11 +1,14 @@
 import { type Color, rgb } from 'pdf-lib';
 
 import { namedColors } from './api/colors.ts';
-import { typeError } from './types.ts';
+import { isObject, typeError } from './types.ts';
 
 export { type Color };
 
 export function readColor(input: unknown): Color {
+  if (isObject(input) && input.type === 'RGB') {
+    return input as unknown as Color;
+  }
   if (typeof input === 'string') {
     if (/^#[0-9a-f]{6}$/.test(input)) {
       const r = parseInt(input.slice(1, 3), 16) / 255;


### PR DESCRIPTION
Reading a `color` property on a row or column block with a nested text block lead to a TypeError:

> TypeError: Invalid value for "definition/content/0/rows/0/color":
> Expected valid color, got: {type: 'RGB', red: 0, green: 0.3, blue:
> 0.5}

This happened because the `readColor()` function transforms the input and did not accept its own result type as input. For nested blocks, the inherited `color` property is parsed twice if not overwritten.

As a quick fix, this commit changes the `readColor()` function to accept its own result type, i.e. an object with type `RGB`.

Fixes https://github.com/eclipsesource/pdf-maker/issues/95